### PR TITLE
use ResizeObserver API instead of window resize events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
+        "@react-hook/resize-observer": "^2.0.2",
         "color": "^5.0.0",
         "i18next": "^25.1.2",
         "i18next-browser-languagedetector": "^8.1.0",
@@ -48,6 +49,10 @@
         "workbox-window": "^7.0.0",
       },
     },
+  },
+  "overrides": {
+    "sharp": "0.32.6",
+    "sharp-ico": "0.1.5",
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
@@ -487,6 +492,12 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@react-hook/latest": ["@react-hook/latest@1.0.3", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="],
+
+    "@react-hook/passive-layout-effect": ["@react-hook/passive-layout-effect@1.2.1", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="],
+
+    "@react-hook/resize-observer": ["@react-hook/resize-observer@2.0.2", "", { "dependencies": { "@react-hook/latest": "^1.0.2", "@react-hook/passive-layout-effect": "^1.2.0" }, "peerDependencies": { "react": ">=18" } }, "sha512-tzKKzxNpfE5TWmxuv+5Ae3IF58n0FQgQaWJmcbYkjXTRZATXxClnTprQ2uuYygYTpu1pqbBskpwMpj6jpT1djA=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
+    "@react-hook/resize-observer": "^2.0.2",
     "color": "^5.0.0",
     "i18next": "^25.1.2",
     "i18next-browser-languagedetector": "^8.1.0",

--- a/src/components/DoubleCard.tsx
+++ b/src/components/DoubleCard.tsx
@@ -1,8 +1,5 @@
 import {
   useState,
-  useRef,
-  useLayoutEffect,
-  useCallback,
   JSX,
   useEffect,
 } from "react";
@@ -12,11 +9,9 @@ import GBImages from "../utils/GBImages";
 import { GBModelExpanded } from "../models/gbdbTypes";
 import { Subscription } from "rxjs";
 import { getSettings } from "../models/settings";
+import useScaleRef from "../hooks/useScaleRef";
 
 export function DoubleCard({ model }: { model: GBModelExpanded }): JSX.Element {
-  const targetRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1.0);
-
   const [cardStyle, setStyle] = useState<"sfg" | "gbcp">("sfg");
 
   useEffect(() => {
@@ -30,21 +25,7 @@ export function DoubleCard({ model }: { model: GBModelExpanded }): JSX.Element {
     return () => sub?.unsubscribe();
   }, []);
 
-  useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  });
-  const updateSize = useCallback(() => {
-    if (!targetRef.current) {
-      return;
-    }
-    const { width, height } = targetRef.current.getBoundingClientRect();
-    const vertScale = width / 1000;
-    const horiScale = height / 700;
-    const newScale = Math.min(vertScale, horiScale, 1);
-    setScale(newScale ?? 1);
-  }, []);
+  const [scale, layoutRef] = useScaleRef<HTMLDivElement>(1000, 700);
 
   const key = model.id;
   const gbcp =
@@ -54,7 +35,7 @@ export function DoubleCard({ model }: { model: GBModelExpanded }): JSX.Element {
 
   return (
     <div
-      ref={targetRef}
+      ref={layoutRef}
       style={{
         width: "100%",
         maxWidth: "1000px",

--- a/src/components/FlipCard.tsx
+++ b/src/components/FlipCard.tsx
@@ -1,17 +1,11 @@
-import {
-  useState,
-  useRef,
-  useLayoutEffect,
-  useCallback,
-  JSX,
-  PropsWithChildren,
-} from "react";
+import { useRef, JSX, PropsWithChildren, } from "react";
 import { CardFront } from "./CardFront";
 import { CardBack } from "./CardBack";
 import "./FlipCard.css";
 
 import { GBModelExpanded } from "../models/gbdbTypes";
 import { Observable } from "rxjs";
+import useScaleRef from "../hooks/useScaleRef";
 
 export function FlipCard({
   children,
@@ -21,24 +15,8 @@ export function FlipCard({
   model: GBModelExpanded;
   health$?: Observable<number>;
 }>): JSX.Element {
-  const layoutRef = useRef<HTMLDivElement>(null);
   const targetRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1);
-  useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  });
-  const updateSize = useCallback(() => {
-    if (!layoutRef.current) {
-      return;
-    }
-    const { width, height } = layoutRef.current.getBoundingClientRect();
-    const vertScale = width / 500;
-    const horiScale = height / 700;
-    const newScale = Math.min(vertScale, horiScale, 1);
-    setScale(newScale ?? 1);
-  }, []);
+  const [scale, layoutRef] = useScaleRef<HTMLDivElement>(500, 700);
 
   return (
     <div

--- a/src/components/Gameplan.tsx
+++ b/src/components/Gameplan.tsx
@@ -1,13 +1,10 @@
 import {
   CSSProperties,
-  useRef,
-  useState,
-  useLayoutEffect,
-  useCallback,
   ReactNode,
 } from "react";
 
 import { Gameplan } from "./DataTypes";
+import useScaleRef from "../hooks/useScaleRef";
 
 interface CardCSS extends CSSProperties {
   "--scale"?: number | string;
@@ -149,29 +146,11 @@ export const GameplanFront = (props: {
 };
 
 const SimpleCard = (props: { children?: ReactNode }) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1.0);
-
-  useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  });
-  const updateSize = useCallback(() => {
-    if (!ref.current) {
-      return;
-    }
-    const { width, height } = ref.current.getBoundingClientRect();
-    const vertScale = width / 500;
-    const horiScale = height / 700;
-    const newScale = Math.min(vertScale, horiScale, 1);
-    setScale(newScale ?? 1);
-  }, []);
-
+  const [scale, layoutRef] = useScaleRef<HTMLDivElement>(500, 700);
   return (
     // layout positioning div
     <div
-      ref={ref}
+      ref={layoutRef}
       style={{
         width: "100%",
         maxWidth: "500px",

--- a/src/components/GuildCard.tsx
+++ b/src/components/GuildCard.tsx
@@ -1,39 +1,20 @@
 import {
-  useState,
   useRef,
-  useLayoutEffect,
   CSSProperties,
-  useCallback,
 } from "react";
 import GBImages from "../utils/GBImages";
 import "./FlipCard.css";
+import useScaleRef from "../hooks/useScaleRef";
 
 interface CardCSS extends CSSProperties {
   "--scale": number | string;
 }
 
 export const DoubleGuildCard = ({ guild }: { guild: string | undefined }) => {
-  const targetRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1.0);
-  useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  });
-  const updateSize = useCallback(() => {
-    if (!targetRef.current) {
-      return;
-    }
-    const { width, height } = targetRef.current.getBoundingClientRect();
-    const vertScale = width / 1000;
-    const horiScale = height / 700;
-    const newScale = Math.min(vertScale, horiScale, 1);
-    setScale(newScale ?? 1);
-  }, []);
-
+  const [scale, layoutRef] = useScaleRef<HTMLDivElement>(1000, 700);
   return (
     <div
-      ref={targetRef}
+      ref={layoutRef}
       style={{
         width: "100%",
         maxWidth: "1000px",
@@ -80,25 +61,8 @@ export const DoubleGuildCard = ({ guild }: { guild: string | undefined }) => {
 };
 
 export function FlipGuildCard({ guild }: { guild: string | undefined }) {
-  const layoutRef = useRef<HTMLDivElement>(null);
   const targetRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1);
-  useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  });
-  const updateSize = useCallback(() => {
-    if (!layoutRef.current) {
-      return;
-    }
-    const { width, height } = layoutRef.current.getBoundingClientRect();
-    const vertScale = width / 500;
-    const horiScale = height / 700;
-    const newScale = Math.min(vertScale, horiScale, 1);
-    setScale(newScale ?? 1);
-  }, []);
-
+  const [scale, layoutRef] = useScaleRef<HTMLDivElement>(500, 700);
   return (
     <div
       ref={layoutRef}

--- a/src/hooks/useScaleRef.tsx
+++ b/src/hooks/useScaleRef.tsx
@@ -1,0 +1,26 @@
+import { RefObject, useCallback, useLayoutEffect, useRef, useState } from "react";
+import useResizeObserver from "@react-hook/resize-observer";
+
+function useScaleRef<T extends Element>(width: number, height: number): [number, RefObject<T | null>] {
+    const target = useRef<T>(null);
+    const [scale, setScale] = useState(1);
+
+    const updateScale = useCallback((box: DOMRectReadOnly) => {
+        const { width: widthLimit, height: heightLimit } = box;
+        const vertScale = widthLimit / width;
+        const horiScale = heightLimit / height;
+        const newScale = Math.min(vertScale, horiScale, 1);
+        setScale(newScale ?? 1);
+    }, [height, width]);
+
+    useLayoutEffect(() => {
+        if (target.current)
+            updateScale(target.current.getBoundingClientRect());
+    }, [target, updateScale]);
+
+    useResizeObserver(target, (entry) => { updateScale(entry.contentRect) });
+
+    return [scale, target];
+}
+
+export default useScaleRef;

--- a/src/pages/GamePlay/Game.tsx
+++ b/src/pages/GamePlay/Game.tsx
@@ -1,9 +1,9 @@
 import {
   useState,
-  useRef,
   useLayoutEffect,
   useEffect,
   useCallback,
+  useRef,
 } from "react";
 import { useBlocker } from "react-router-dom";
 import type { BlockerFunction } from "react-router";
@@ -39,6 +39,7 @@ import { useRxData } from "../../hooks/useRxQuery";
 import { NetworkGame } from "../../components/NetworkGame";
 import { useNetworkState } from "../../hooks/useNetworkState";
 import { useGameState } from "../../hooks/useGameState";
+import useResizeObserver from "@react-hook/resize-observer";
 
 export default function Game() {
   const [showSnack, setShowSnack] = useState(false);
@@ -248,7 +249,7 @@ const GameList = ({
 }) => {
   const theme = useTheme();
   const large = useMediaQuery(theme.breakpoints.up("sm"));
-  const sizeRef = useRef<HTMLDivElement>(null);
+
   const [open, setOpen] = useState(false);
   const [index, setIndex] = useState(0);
   const [expanded, setExpanded] = useState(true);
@@ -256,20 +257,22 @@ const GameList = ({
   const [cardWidth, setCardWidth] = useState(500);
   const [cardHeight, setCardHeight] = useState(700);
   const [slideHeight, setSlideHeight] = useState(700);
-  useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  });
 
-  const updateSize = useCallback(() => {
-    const width = sizeRef.current?.getBoundingClientRect().width ?? 0;
-    const height = sizeRef.current?.getBoundingClientRect().height ?? 0;
+  const updateSize = useCallback(({ width, height }: DOMRectReadOnly) => {
     const barHeight = large ? 56 : 112;
     setCardWidth(Math.min(width - 12, ((height - barHeight) * 5) / 7 - 12));
     setCardHeight(Math.min(height - barHeight - 12, (width * 7) / 5 - 12));
     setSlideHeight(height - barHeight);
   }, [large]);
+
+  const sizeRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (sizeRef.current)
+      updateSize(sizeRef.current.getBoundingClientRect());
+  }, [sizeRef, updateSize]);
+
+  useResizeObserver(sizeRef, (entry) => updateSize(entry.contentRect));
 
   return (
     <div

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -53,6 +53,7 @@ import { GameplanCard, ReferenceCard } from "../components/Gameplan";
 import { GBGuildDoc, GBModelExpanded } from "../models/gbdbTypes";
 import { firstValueFrom, Observable } from "rxjs";
 import { SettingsDoc } from "../models/settings";
+import useResizeObserver from "@react-hook/resize-observer";
 
 export default function Library() {
   const location = useLocation();
@@ -165,14 +166,12 @@ function SwiperLayout({
   slides,
   largeLayout = false,
 }: SwiperLayoutProps) {
-
-  const ref = useRef<HTMLDivElement>(null);
   const [cardWidth, setCardWidth] = useState(0);
   const [cardHeight, setCardHeight] = useState(0);
 
-  const updateSize = useCallback(() => {
-    const containerWidth = ref.current?.getBoundingClientRect().width ?? (largeLayout ? 1000 : 500);
-    const containerHeight = ref.current?.getBoundingClientRect().height ?? 700;
+  const updateSize = useCallback(({ width, height }: DOMRectReadOnly) => {
+    const containerWidth = width ?? (largeLayout ? 1000 : 500);
+    const containerHeight = height ?? 700;
     const aspectRatioMultiplier = largeLayout ? 10 : 5;
     const calculatedWidth = Math.min(containerWidth, (containerHeight * aspectRatioMultiplier) / 7) - 12;
     const calculatedHeight = Math.min(containerHeight, (containerWidth * 7) / aspectRatioMultiplier) - 12;
@@ -180,11 +179,14 @@ function SwiperLayout({
     setCardHeight(calculatedHeight);
   }, [largeLayout]);
 
+  const sizeRef = useRef<HTMLDivElement>(null);
+
   useLayoutEffect(() => {
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  }, [updateSize]);
+    if (sizeRef.current)
+      updateSize(sizeRef.current.getBoundingClientRect());
+  }, [sizeRef, updateSize]);
+
+  useResizeObserver(sizeRef, (entry) => updateSize(entry.contentRect));
 
   const [swiper, setSwiper] = useState<SwiperRef | null>(null);
   // I don't like this, it's just triggering a re-render which then also renders the buttons
@@ -196,7 +198,7 @@ function SwiperLayout({
     <>
       {navigation(swiper)}
       <Box
-        ref={ref}
+        ref={sizeRef}
         sx={{
           height: "100%",
           position: "relative",


### PR DESCRIPTION
factor out card scale calculations to a hook for reuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved component scaling and resizing responsiveness by introducing a new custom hook for automatic scale calculation.
- **Refactor**
	- Simplified scaling logic across multiple card and layout components to use a unified hook, reducing manual resize handling and improving code maintainability.
- **Chores**
	- Added a new dependency for resize observation to enhance performance and accuracy of UI resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->