### PR TITLE
Fix up the mess I made earlier, card export looking fine!

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1229,7 +1229,7 @@
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
-    "modern-screenshot": ["modern-screenshot@github:cleech/modern-screenshot#da3f7a7", {}, "cleech-modern-screenshot-da3f7a7"],
+    "modern-screenshot": ["modern-screenshot@github:cleech/modern-screenshot#26d2405", {}, "cleech-modern-screenshot-26d2405"],
 
     "mongodb": ["mongodb@6.10.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.1.5", "bson": "^6.7.0", "mongodb-connection-string-url": "^3.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.2.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg=="],
 

--- a/src/components/CardFront.css
+++ b/src/components/CardFront.css
@@ -200,15 +200,8 @@ div.card-front.gbcp.double {
 }
 
 .dropcap span::first-letter {
-  float: left;
-  padding-top: 0.075em;
-}
+  vertical-align: -7.5%;
 
-@supports (-moz-appearance:none) {
-  .dropcap span::first-letter {
-    float: unset;
-    padding: inherit;
-  }
 }
 
 .card-front .name-plate-right > .reach {

--- a/src/components/GBIcon.tsx
+++ b/src/components/GBIcon.tsx
@@ -147,7 +147,7 @@ export default function GBIcon(props: GBIconProps) {
   };
 
   return (
-    iconMap[icon]({ className: className, style: computedStyle, ...otherProps })
+    iconMap[icon]?.({ className: className, style: computedStyle, ...otherProps }) ?? null
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+// import { lazy } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 
@@ -11,20 +11,20 @@ import {
 
 import App, { AppContent } from "./pages/App";
 
-const GamePlay = lazy(() => import("./pages/GamePlay"));
-const TeamSelect = lazy(() => import("./pages/GamePlay/TeamSelect"));
-const Draft = lazy(() => import("./pages/GamePlay/Draft"));
-const Game = lazy(() => import("./pages/GamePlay/Game"));
+import GamePlay from "./pages/GamePlay";
+import TeamSelect from "./pages/GamePlay/TeamSelect";
+import Draft from "./pages/GamePlay/Draft";
+import Game from "./pages/GamePlay/Game";
 
-const Library = lazy(() => import("./pages/Library"));
-const LibraryCarousel = lazy(() => import("./pages/Library/LibraryCarousel"));
-const GamePlans = lazy(() => import("./pages/Library/GamePlans"));
-const GuildList = lazy(() => import("./pages/Library/GuildList"));
-const RefCards = lazy(() => import("./pages/Library/RefCards"));
-const Roster = lazy(() => import("./pages/Library/Roster"));
+import Library from "./pages/Library";
+import LibraryCarousel from "./pages/Library/LibraryCarousel";
+import GamePlans from "./pages/Library/GamePlans";
+import GuildList from "./pages/Library/GuildList";
+import RefCards from "./pages/Library/RefCards";
+import Roster from "./pages/Library/Roster";
 
-const Settings = lazy(() => import("./pages/Settings"));
-const CardPrintScreen = lazy(() => import("./pages/Print"));
+import Settings from "./pages/Settings";
+import CardPrintScreen from "./pages/Print";
 
 import { getSettings, SettingsDoc } from "./models/settings";
 import { defaultSettings } from "./models/defaultSettings";

--- a/src/pages/Print/components/DownloadDialog.tsx
+++ b/src/pages/Print/components/DownloadDialog.tsx
@@ -167,12 +167,15 @@ async function downloadCards(
 
   const files: { file: string, blob: Blob }[] = [];
 
+  const root = document.querySelector<HTMLElement>('#root');
+  const saved_root_overflow = root!.style.overflow;
+  root!.style.overflow = 'hidden';
+
   const promises = Array.from(elements).map(async (el) => {
 
     const copiedNode = el.cloneNode(true) as HTMLElement;
     const container = copiedNode.firstElementChild as HTMLElement;
 
-    container.style.visibility = 'hidden';
     const isDouble = el.classList.contains('double');
     container.style.width =
       isDouble
@@ -181,7 +184,7 @@ async function downloadCards(
     container.style.height = withBleed ? '750px' : '700px';
     container.style.setProperty('--scale', '1');
 
-    document.body.appendChild(copiedNode);
+    root!.appendChild(copiedNode);
 
     const context = await ScreenShot.createContext(container, {
       debug: debug,
@@ -196,7 +199,7 @@ async function downloadCards(
     ));
 
     const blob = await ScreenShot.domToBlob(context);
-    document.body.removeChild(copiedNode);
+    root!.removeChild(copiedNode);
 
     if (debug) {
       const img = new Image();
@@ -209,6 +212,7 @@ async function downloadCards(
   });
 
   await Promise.all(promises);
+  root!.style.overflow = saved_root_overflow;
 
   if (files.length !== 0) {
     const zip = new JSZip();

--- a/src/pages/Print/components/DownloadDialog.tsx
+++ b/src/pages/Print/components/DownloadDialog.tsx
@@ -191,9 +191,8 @@ async function downloadCards(
       type: `image/${type}`,
       scale: (height / (withBleed ? 750 : 700)),
     })
-    // modern-screenshot trys to do everything with applied styles,
-    //  but it misses ::first-letter pseudo-elements
-    // Just inject the CSS rule and it will get applied again in the SVG
+    // Inject CSS for dropcap first-letter pseudo-element that modern-screenshot misses
+    // The -7.5% vertical-align value matches the styling in CardFront.css
     context.svgStyleElement?.appendChild(document.createTextNode(
       '.dropcap span::first-letter { vertical-align: -7.5%; }'
     ));
@@ -204,7 +203,10 @@ async function downloadCards(
     if (debug) {
       const img = new Image();
       img.src = URL.createObjectURL(blob);
-      img.onclick = () => document.body.removeChild(img);
+      img.onclick = () => {
+        document.body.removeChild(img);
+        URL.revokeObjectURL(img.src);
+      }
       document.body.appendChild(img);
     } else {
       files.push({ file: `${el.id}.${type}`, blob });

--- a/src/pages/Print/components/DownloadDialog.tsx
+++ b/src/pages/Print/components/DownloadDialog.tsx
@@ -12,12 +12,16 @@ import FileSaver from "file-saver";
 
 import { PrintSettingsType } from "./PrintSettingsContext";
 import usePrintSettings from "./usePrintSettings";
+import { useSearchParams } from "react-router-dom";
 
 export default function DownloadDialog() {
   const [dialogOpen, setDialog] = useState(false);
   const [fileName, setFileName] = useState("GB-cards.zip");
   const [imgType, setImgType] = useState("png");
   const [waiting, setWaiting] = useState(false);
+
+  const [searchParams] = useSearchParams();
+  const debug = searchParams.has("debug");
 
   const settings = usePrintSettings();
   const {
@@ -123,7 +127,7 @@ export default function DownloadDialog() {
             disabled={waiting}
             onClick={() => {
               setWaiting(true);
-              downloadCards(fileName, imgType, settings).finally(() => {
+              downloadCards(fileName, imgType, settings, debug).finally(() => {
                 setWaiting(false);
                 setDialog(false);
               });
@@ -151,7 +155,9 @@ export default function DownloadDialog() {
   </>)
 }
 
-async function downloadCards(fileName: string, type: string, settings: PrintSettingsType) {
+async function downloadCards(
+  fileName: string, type: string,
+  settings: PrintSettingsType, debug?: boolean) {
   if (!fileName || !settings) return;
 
   const { withBleed, height } = settings;
@@ -159,13 +165,14 @@ async function downloadCards(fileName: string, type: string, settings: PrintSett
   const elements = document.querySelectorAll('.card:not(.hide)');
   if (elements.length === 0) return;
 
-  const zip = new JSZip();
+  const files: { file: string, blob: Blob }[] = [];
 
   const promises = Array.from(elements).map(async (el) => {
 
     const copiedNode = el.cloneNode(true) as HTMLElement;
     const container = copiedNode.firstElementChild as HTMLElement;
 
+    container.style.visibility = 'hidden';
     const isDouble = el.classList.contains('double');
     container.style.width =
       isDouble
@@ -176,41 +183,39 @@ async function downloadCards(fileName: string, type: string, settings: PrintSett
 
     document.body.appendChild(copiedNode);
 
-    const blob = await ScreenShot.domToBlob(container, {
+    const context = await ScreenShot.createContext(container, {
+      debug: debug,
       type: `image/${type}`,
       scale: (height / (withBleed ? 750 : 700)),
-    }).then((_blob) => ScreenShot.domToBlob(container, {
-      type: `image/${type}`,
-      scale: (height / (withBleed ? 750 : 700)),
-    })).then((_blob) => ScreenShot.domToBlob(container, {
-      type: `image/${type}`,
-      scale: (height / (withBleed ? 750 : 700)),
-    }));
+    })
+    // modern-screenshot trys to do everything with applied styles,
+    //  but it misses ::first-letter pseudo-elements
+    // Just inject the CSS rule and it will get applied again in the SVG
+    context.svgStyleElement?.appendChild(document.createTextNode(
+      '.dropcap span::first-letter { vertical-align: -7.5%; }'
+    ));
 
-    //await ScreenShot.domToForeignObjectSvg(container, {
-    //  scale: (height / (withBleed ? 750 : 700)),
-    //}).then(svg => document.body.appendChild(svg));
-    //
-    //await ScreenShot.domToSvg(container, {
-    //  scale: (height / (withBleed ? 750 : 700)),
-    //}).then(svgUrl => {
-    //  const img = new Image();
-    //  img.src = svgUrl;
-    //  document.body.appendChild(img);
-    //});
-
+    const blob = await ScreenShot.domToBlob(context);
     document.body.removeChild(copiedNode);
 
-    if (blob) {
-      //const img = new Image();
-      //img.src = URL.createObjectURL(blob);
-      //document.body.appendChild(img);
-
-      zip.file(`${el.id}.${type}`, blob);
+    if (debug) {
+      const img = new Image();
+      img.src = URL.createObjectURL(blob);
+      img.onclick = () => document.body.removeChild(img);
+      document.body.appendChild(img);
+    } else {
+      files.push({ file: `${el.id}.${type}`, blob });
     }
   });
 
   await Promise.all(promises);
-  const blob = await zip.generateAsync({ type: "blob" });
-  FileSaver.saveAs(blob, fileName);
+
+  if (files.length !== 0) {
+    const zip = new JSZip();
+    for (const { file, blob } of files) {
+      zip.file(file, blob);
+    }
+    const blob = await zip.generateAsync({ type: "blob" });
+    FileSaver.saveAs(blob, fileName);
+  }
 }

--- a/src/pages/Print/index.tsx
+++ b/src/pages/Print/index.tsx
@@ -199,6 +199,7 @@ export default function CardPrintScreen() {
           flexDirection: "column",
           width: "100%",
           height: "100%",
+          overflow: "hidden",
         }}
       >
         <AppBarContent>

--- a/src/pages/Print/index.tsx
+++ b/src/pages/Print/index.tsx
@@ -1095,8 +1095,8 @@ const GuildCard = (props: {
       {inView && (
         <div
           style={{
-            width: width,
-            height: height,
+            width: "100%",
+            height: "100%",
             display: "inline-flex",
             flexDirection: "row",
             gap: 0,
@@ -1108,7 +1108,7 @@ const GuildCard = (props: {
             }
             style={{
               backgroundImage: `url(${GBImages.get(`${name}_front`)})`,
-              width: width,
+              height: "100%",
               borderRadius: 0,
             }}
           />
@@ -1118,7 +1118,7 @@ const GuildCard = (props: {
             }
             style={{
               backgroundImage: `url(${GBImages.get(`${name}_back`)})`,
-              width: width,
+              height: "100%",
               borderRadius: 0,
             }}
           />


### PR DESCRIPTION
Card export as PNG and JPEG

+ better drop-cap css that actually works in firefox

Clean up ugly mistakes from earlier ... not ready for lazy loading and code splitting until I finish isolating CSS correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of missing or invalid icons to prevent runtime errors.
	- Fixed rendering issues with drop caps in card downloads for better visual consistency.
- **Style**
	- Updated drop cap styling for improved vertical alignment and consistency across browsers.
	- Adjusted print layout to better handle overflow and ensure card images scale correctly.
- **New Features**
	- Added a debug mode for card downloads, allowing users to preview generated images directly.
- **Refactor**
	- Switched from dynamic to static imports for page components to improve loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->