### PR TITLE
Guild Grid / List Ordering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,8 @@
     "": {
       "name": "gb-playbook",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -272,6 +274,14 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20251011.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RIXUQRchFdqEvaUqn1cXZXSKjpqMaSaVAkI5jNZ8XzAw/bw2bcdOVUtakrflgxDprltjFb0PTNtuss1FKtH9Jg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@emotion/babel-plugin": ["@emotion/babel-plugin@11.13.5", "", { "dependencies": { "@babel/helper-module-imports": "^7.16.7", "@babel/runtime": "^7.18.3", "@emotion/hash": "^0.9.2", "@emotion/memoize": "^0.9.0", "@emotion/serialize": "^1.3.3", "babel-plugin-macros": "^3.1.0", "convert-source-map": "^1.5.0", "escape-string-regexp": "^4.0.0", "find-root": "^1.1.0", "source-map": "^0.5.7", "stylis": "4.2.0" } }, "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ=="],
 
@@ -853,7 +863,7 @@
 
     "color-string": ["color-string@2.0.1", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ=="],
 
-    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 
@@ -2245,8 +2255,6 @@
 
     "terser/acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
 
-    "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
-
     "tinyglobby/fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
@@ -2276,6 +2284,8 @@
     "workbox-build/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
 
     "workbox-build/source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
+
+    "z-schema/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/src/components/GridSettingsMenu.tsx
+++ b/src/components/GridSettingsMenu.tsx
@@ -1,0 +1,95 @@
+import { useState, MouseEvent } from "react";
+import { IconButton, Menu, Tooltip, Typography, List, ListItemButton, ListItemText, Divider } from "@mui/material";
+import { Apps as Icon } from "@mui/icons-material";
+import { reSort } from "../utils/reSort";
+
+interface GuildInfo {
+  key: string,
+  id: string,
+  name: string,
+  icon: string,
+  disabled: boolean,
+}
+
+const pairedOrder = [
+  'Alchemists', 'Lamplighters', 'Blacksmiths', 'Brewers', 'Butchers', 'Cooks', 'Engineers', 'Miners', 'Farmers', 'Shepherds', 'Fishermen', 'Navigators', 'Hunters', 'Falconers', 'Masons', 'Lumberjacks', 'Morticians', 'Ratcatchers', 'Union', 'Order'
+];
+
+export default function GridSettingsMenu(props: {
+  list: GuildInfo[],
+  setList: (arg: GuildInfo[]) => void,
+  edit: boolean,
+  setEdit: (arg: boolean) => void,
+}) {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement>();
+  const menuOpen = Boolean(menuAnchor);
+
+  const menuIconClick = (e: MouseEvent<HTMLElement>) => {
+    if (props.edit)
+      props.setEdit(false);
+    else
+      setMenuAnchor(e.currentTarget);
+  }
+
+  const menuClose = () => {
+    setMenuAnchor(undefined);
+  }
+
+  const [tipShown, setTipShown] = useState(false);
+
+  return (
+    <>
+      <Tooltip arrow
+        title={props.edit ? "Done Editing" : "Grid Customization"}
+        placement="left"
+        open={tipShown || props.edit}
+        onOpen={() => setTipShown(true)}
+        onClose={() => setTipShown(false)}
+      >
+        <IconButton size="small" onClick={menuIconClick}>
+          <Icon {...(props.edit ? { color: 'success' } : {})} />
+        </IconButton>
+      </Tooltip >
+      <Menu
+        open={menuOpen}
+        onClose={menuClose}
+        anchorEl={menuAnchor}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <List>
+          <ListItemText>
+            <Typography textAlign="center">
+              Grid Layout
+            </Typography>
+          </ListItemText>
+          <Divider />
+          <ListItemButton onClick={() => {
+            props.setList([...props.list].sort((a, b) => a.id.localeCompare(b.id)));
+          }}>
+            <ListItemText>
+              Reset to Alphabetical
+            </ListItemText>
+          </ListItemButton>
+
+          <ListItemButton onClick={() => {
+            props.setList(reSort([...props.list], "id", pairedOrder));
+          }}>
+            <ListItemText>
+              Pair Minors with Majors
+            </ListItemText>
+          </ListItemButton>
+
+          <ListItemButton onClick={() => {
+            props.setEdit(true);
+            menuClose();
+          }}>
+            <ListItemText>
+              Custom Order
+            </ListItemText>
+          </ListItemButton>
+        </List>
+      </Menu >
+    </>
+  )
+}

--- a/src/components/GuildGrid.tsx
+++ b/src/components/GuildGrid.tsx
@@ -7,6 +7,14 @@ import GBIcon from "../components/GBIcon";
 import { GBGuildDoc } from "../models/gbdbTypes";
 import { Observable, fromEventPattern } from "rxjs";
 
+import { closestCenter, DndContext, DragEndEvent, MouseSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { arrayMove, rectSortingStrategy, SortableContext, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useData } from "../hooks/useData";
+import { css, cx, keyframes } from "@emotion/css";
+import { AppBarContent } from "../pages/App";
+import GridSettingsMenu from "./GridSettingsMenu";
+
 function maxBy<T>(data: Array<T>, by: (v: T) => number) {
   return data.reduce((a, b) => (by(a) >= by(b) ? a : b));
 }
@@ -56,6 +64,7 @@ export interface ControlProps {
 }
 
 interface GridIcon {
+  id: string;
   key: string;
   name: string;
   icon: string;
@@ -68,6 +77,47 @@ interface GuildGridProps {
   Controller: ComponentType<ControlProps>;
 }
 
+const wiggle = css({
+  '&> :nth-child(odd) > button': {
+    animationName: keyframes({
+      '0%': {
+        transform: 'rotate(-1deg)',
+        animationTimingFunction: 'ease-in',
+      },
+      '50%': {
+        transform: 'rotate(1.5deg)',
+        animationTimingFunction: 'ease-out',
+      }
+    }),
+    transformOrigin: '50% 10%',
+  },
+  '&> :nth-child(even) > button': {
+    animationName: keyframes({
+      '0%': {
+        transform: 'rotate(1deg)',
+        animationTimingFunction: 'ease-in',
+      },
+      '50%': {
+        transform: 'rotate(-1.5deg)',
+        animationTimingFunction: 'ease-out',
+      }
+    }),
+    transformOrigin: '30% 5%',
+  },
+  '&> div > button': {
+    animationIterationCount: 'infinite',
+    animationDirection: 'alternate',
+  },
+  '&> :nth-child(3n) > button': { animationDelay: '0s' },
+  '&> :nth-child(3n-1) > button': { animationDelay: '-0.1s' },
+  '&> :nth-child(3n-2) > button': { animationDelay: '-0.2s' },
+  '&> :nth-child(5n) > button': { animationDuration: '.45s' },
+  '&> :nth-child(5n-1) > button': { animationDuration: '.2s' },
+  '&> :nth-child(5n-2) > button': { animationDuration: '.3s' },
+  '&> :nth-child(5n-3) > button': { animationDuration: '.4s' },
+  '&> :nth-child(5n-4) > button': { animationDuration: '.33s' },
+});
+
 export function GuildGrid({
   guilds,
   Controller,
@@ -77,7 +127,7 @@ export function GuildGrid({
   const ref = useRef<HTMLDivElement>(null);
   const [size, setSize] = React.useState<number>(0);
   const updateSize = useCallback(({ width, height }: DOMRectReadOnly) => {
-    const count = guilds?.length ?? 0;
+    const count = guilds.length;
     const size = itemSize({ width, height }, count, 1)?.size ?? 0;
     setSize(size);
   }, [guilds]);
@@ -130,44 +180,94 @@ export function GuildGrid({
 
 const GuildGridInner = React.memo(
   (props: {
-    guilds?: GBGuildDoc[];
+    guilds: GBGuildDoc[];
     pickTeam?: (guild: string) => void;
     size: number;
   }) => {
     const { pickTeam, size, guilds } = props;
+    const { gbdb } = useData();
 
-    if (!guilds) {
-      return null;
+    const [edit, setEdit] = useState(false);
+
+    const sensors = useSensors(
+      useSensor(TouchSensor),
+      useSensor(MouseSensor),
+      // useSensor(PointerSensor),
+      // useSensor(KeyboardSensor, {
+      //   coordinateGetter: sortableKeyboardCoordinates
+      // }),
+    );
+
+    const [list, setList] = useState(
+      (guilds).map((g) => ({
+        key: g.name,
+        id: g.name,
+        name: g.name,
+        icon: g.name,
+        disabled: g.roster.length === 0,
+      }))
+    );
+
+    const handleDragEnd = async (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over) {
+        return;
+      }
+      if (active.id !== over.id) {
+        const oldIndex = list.findIndex((element) => element.id === active.id);
+        const newIndex = list.findIndex((element) => element.id === over.id);
+        const newList = arrayMove(list, oldIndex, newIndex);
+        setList(newList);
+        const settings = await gbdb?.getLocal("settings");
+        await settings?.incrementalPatch({
+          customListOrder: newList.map((g) => g.name)
+        }).catch(console.error);
+      }
     }
 
-    const list: GridIcon[] = (guilds as GBGuildDoc[]).map((g: GBGuildDoc) => ({
-      key: g.name,
-      name: g.name,
-      icon: g.name,
-      disabled: g.roster.length === 0,
-    }));
-
     return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-          alignContent: "flex-start",
-          justifyContent: "space-evenly",
-          // width: "100%",
-          // height: "100%",
-          gap: "10px",
-          padding: "5px",
-          // flexBasis: "100%",
-          // flexShrink: 1,
-          overflow: "clip",
-        }}
-      >
-        {list.map((g) => (
-          <GridIconButton key={g.key} g={g} pickTeam={pickTeam} size={size} />
-        ))}
-      </div>
+      <>
+        <AppBarContent>
+          <GridSettingsMenu edit={edit} setEdit={setEdit}
+            list={list} setList={async (gs) => {
+              setList(gs);
+              const settings = await gbdb?.getLocal("settings");
+              await settings?.incrementalPatch({
+                customListOrder: gs.map((g) => g.name)
+              }).catch(console.error);
+            }}
+          />
+        </AppBarContent>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext disabled={!edit} items={list} strategy={rectSortingStrategy}>
+            <div
+              className={cx({ [wiggle]: edit })}
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "wrap",
+                alignContent: "flex-start",
+                justifyContent: "space-evenly",
+                // width: "100%",
+                // height: "100%",
+                gap: "10px",
+                padding: "5px",
+                // flexBasis: "100%",
+                // flexShrink: 1,
+                overflow: "clip",
+              }}
+            >
+              {list.map((g) => (
+                <GridIconButton key={g.key} g={g} pickTeam={pickTeam} size={size} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </>
     );
   }
 );
@@ -178,73 +278,83 @@ export function GridIconButton(props: {
   size: number;
 }) {
   const { g, pickTeam, size } = props;
+  const sortable = useSortable({ id: g.id });
   return (
-    <Button
-      key={g.key}
-      disabled={props.g.disabled}
-      variant="outlined"
-      onClick={() => pickTeam?.(g.key)}
+    <div ref={sortable.setNodeRef}
       style={{
-        display: "flex",
-        flexDirection: "column",
-        minWidth: size,
-        minHeight: size,
-        maxWidth: size,
-        maxHeight: size,
-        background: "rgba(100%, 100%, 100%, 15%)",
-        backdropFilter: "blur(10px)",
+        transform: CSS.Transform.toString(sortable.transform),
+        transition: sortable.transition,
       }}
-      sx={{
-        "@media (hover: hover)": {
-          "& > div": {
-            transition: "transform .25s",
-          },
-          "&:hover > div": {
-            transform: "scale(1.2)",
-          },
-        },
-      }}
+      {...sortable.listeners}
+      {...sortable.attributes}
     >
-      <div
+      <Button
+        key={g.key}
+        disabled={props.g.disabled}
+        variant="outlined"
+        onClick={() => pickTeam?.(g.key)}
         style={{
           display: "flex",
-          placeContent: "center",
-          placeItems: "center",
-          fontSize: size * 0.7,
-          // fontSize: size / 1.3125,
-          width: "1em",
-          height: "1em",
-          borderRadius: "50%",
-          padding: "0.0625em",
-          background: "content-box linear-gradient(to bottom, #000, #333)",
-          filter: (props.g.disabled ? "grayscale(0.8)" : "unset"),
+          flexDirection: "column",
+          minWidth: size,
+          minHeight: size,
+          maxWidth: size,
+          maxHeight: size,
+          background: "rgba(100%, 100%, 100%, 15%)",
+          backdropFilter: "blur(10px)",
+        }}
+        sx={{
+          "@media (hover: hover)": {
+            "& > div": {
+              transition: "transform .25s",
+            },
+            "&:hover > div": {
+              transform: "scale(1.2)",
+            },
+          },
         }}
       >
-        <GBIcon
-          icon={g.icon}
-          className="dark"
+        <div
           style={{
-            flexShrink: 0,
-            // zIndex: 1,
-            // filter: "drop-shadow(0 0 3px black)",
-            filter: "drop-shadow(0 0 0.03em black)",
-            ...(g.style || {}),
+            display: "flex",
+            placeContent: "center",
+            placeItems: "center",
+            fontSize: size * 0.7,
+            // fontSize: size / 1.3125,
+            width: "1em",
+            height: "1em",
+            borderRadius: "50%",
+            padding: "0.0625em",
+            background: "content-box linear-gradient(to bottom, #000, #333)",
+            filter: (props.g.disabled ? "grayscale(0.8)" : "unset"),
           }}
-        />
-      </div>
-      <Typography
-        variant="caption"
-        style={{
-          color: props.g.disabled ? "darkgrey" : "whitesmoke",
-          // letterSpacing: "normal",
-          textTransform: "capitalize",
-          textShadow:
-            "1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black, -1px 1px 1px black, 0 1px 1px black, 1px 0 1px black, 0 -1px 1px black, -1px 0 1px black",
-          zIndex: 1,
-        }}
-      >
-        {g.name}
-      </Typography>
-    </Button>
+        >
+          <GBIcon
+            icon={g.icon}
+            className="dark"
+            style={{
+              flexShrink: 0,
+              // zIndex: 1,
+              // filter: "drop-shadow(0 0 3px black)",
+              filter: "drop-shadow(0 0 0.03em black)",
+              ...(g.style || {}),
+            }}
+          />
+        </div>
+        <Typography
+          variant="caption"
+          style={{
+            color: props.g.disabled ? "darkgrey" : "whitesmoke",
+            // letterSpacing: "normal",
+            textTransform: "capitalize",
+            textShadow:
+              "1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black, -1px 1px 1px black, 0 1px 1px black, 1px 0 1px black, 0 -1px 1px black, -1px 0 1px black",
+            zIndex: 1,
+          }}
+        >
+          {g.name}
+        </Typography>
+      </Button>
+    </div >
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,15 @@ import { defaultSettings } from "./models/defaultSettings";
 import "./utils/i18next";
 import { reSort } from "./utils/reSort";
 import LoadingSplash from "./components/LoadingSplash";
+import { GBDatabase } from "./models/gbdbTypes";
+
+async function sortedGuilds(db: GBDatabase) {
+  const guilds = await db.guilds.find().exec();
+  const settings = await db.getLocal<SettingsDoc>("settings");
+  const listOrder = settings?.get("customListOrder") ?? [];
+  reSort(guilds, "name", listOrder);
+  return guilds;
+}
 
 const router = createBrowserRouter(
   [{
@@ -99,7 +108,7 @@ const router = createBrowserRouter(
                   const initializeAppData = (await import("./components/appData")).initializeAppData;
                   return async () => {
                     const { gbdb: db } = await initializeAppData();
-                    return await db.guilds.find().exec();
+                    return await sortedGuilds(db);
                   }
                 },
               },
@@ -121,7 +130,7 @@ const router = createBrowserRouter(
                   const initializeAppData = (await import("./components/appData")).initializeAppData;
                   return async () => {
                     const { gbdb: db } = await initializeAppData();
-                    return await db.guilds.find().exec();
+                    return await sortedGuilds(db);
                   }
                 },
               },
@@ -163,7 +172,7 @@ const router = createBrowserRouter(
               const initializeAppData = (await import("./components/appData")).initializeAppData;
               return async () => {
                 const { gbdb: db } = await initializeAppData();
-                return await db.guilds.find().exec();
+                return await sortedGuilds(db);
               }
             }
           }

--- a/src/models/settings.tsx
+++ b/src/models/settings.tsx
@@ -21,6 +21,7 @@ export interface Settings {
   libraryRoute: string;
   // auto switch on new major release
   mostRecentErrata?: string;
+  customListOrder?: string[];
 }
 
 export type SettingsDoc = RxLocalDocument<GBDatabase, Settings>;

--- a/src/pages/Library/GuildList.tsx
+++ b/src/pages/Library/GuildList.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Typography,
   Breadcrumbs,
+  Box,
 } from "@mui/material";
 
 import {
@@ -36,9 +37,17 @@ export default function GuildList() {
   return (
     <>
       <AppBarContent>
-        <Breadcrumbs separator={<NavigateNext fontSize="small" />}>
-          <Typography>Library</Typography>
-        </Breadcrumbs>
+        <Box sx={{
+          display: "flex",
+          width: "100%",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between"
+        }}>
+          <Breadcrumbs separator={<NavigateNext fontSize="small" />}>
+            <Typography>Library</Typography>
+          </Breadcrumbs>
+        </Box>
       </AppBarContent>
       <GuildGrid guilds={guilds} Controller={ExtraIconsControl} />
       <VersionTag />
@@ -64,6 +73,7 @@ function ExtraIconsControl(props: ControlProps) {
     >
       <GridIconButton
         g={{
+          id: "gameplans",
           key: "gameplans",
           name: "gameplans",
           icon: "GB",
@@ -74,6 +84,7 @@ function ExtraIconsControl(props: ControlProps) {
       />
       <GridIconButton
         g={{
+          id: "refcards",
           key: "refcards",
           name: "Rules",
           icon: "GB",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -157,8 +157,8 @@ const Settings = () => {
 
       <Typography>UI Options:</Typography>
 
+      <p />
       <Typography>Initial Screen:</Typography>
-
       <FormControl>
         <Select
           value={settingsDoc?.toJSON().data.initialScreen}


### PR DESCRIPTION
drag-n-drop sortable guild lists
grid control menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guild grid items are now draggable and can be reordered.
  * New grid settings menu lets you reset, pair, or enter custom-order editing.
  * Custom guild order is persisted and respected across app screens.

* **UI/UX Improvements**
  * Draggable items show an animated wiggle in edit mode.
  * Minor layout and spacing tweaks in the library and settings pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->