### PR TITLE
Improve spanish translation

### DIFF
--- a/public/data/GB-Playbook-4-8.es.json
+++ b/public/data/GB-Playbook-4-8.es.json
@@ -439,7 +439,7 @@
         "Midas Touch",
         "Unpredictable Movement"
       ],
-      "legendary": "Magnum Opus [Pulso de 6″]\nLos modelos oponentes dentro de este pulso obtienen las condiciones de Poison y Burning. Los modelos aliados dentro de este pulso obtienen Fulmanación.",
+      "legendary": "Magnum Opus [Pulso de 6″]\nLos modelos enemigos dentro de este pulso obtienen las condiciones de Poison y Burning. Los modelos aliados dentro de este pulso obtienen Fulmination.",
       "types": "Valentian, Humano, Hombre, \nDelantero,\nCapitán",
       "playbook": [
         [
@@ -494,7 +494,7 @@
         "Unpredictable Movement",
         "Watch The World Burn [4″ Pulse]"
       ],
-      "legendary": "Chemical Shower [Pulso de 6″]\nLos modelos oponentes dentro de este pulso que tengan la condición de Burning o Poison reciben 3 DAÑO de condición.",
+      "legendary": "Chemical Shower [Pulso de 6″]\nLos modelos enemigos dentro de este pulso que tengan la condición de Burning o Poison reciben 3 DAÑO de condición.",
       "types": "Ethraynnian, Humano, Mujer, \nZaguero,\nCapitán",
       "playbook": [
         [
@@ -548,7 +548,7 @@
         "Burning Spirit [2″ Aura]",
         "Gimme Fuel..."
       ],
-      "legendary": "Gimme Fire! [Pulso de 6″]\nLos modelos oponentes dentro de este pulso reciben la condición de Burning. Reemplazá carta de este modelo por la carta de Pneuma.",
+      "legendary": "Gimme Fire! [Pulso de 6″]\nLos modelos enemigos dentro de este pulso reciben la condición de Burning. Reemplaza la carta de este modelo por la carta de Pneuma.",
       "types": "Desconocido, Humano, Desconocido,\nD.T.,\nCapitán",
       "playbook": [
         [
@@ -810,7 +810,7 @@
         "Extraction",
         "Noxious Death [3″ Pulse]"
       ],
-      "types": "Ethraynnian, Humano, Mujer, \nPuntero,\nVeteranoo, Seguidor",
+      "types": "Ethraynnian, Humano, Mujer, \nPuntero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -1022,7 +1022,7 @@
         "Venomous Strike",
         "Witness Me!"
       ],
-      "types": "Skaldic, Humano, Hombre, \nEnganche,\nVeteranoo, Seguidor",
+      "types": "Skaldic, Humano, Hombre, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           ">;M",
@@ -1129,7 +1129,7 @@
         "Secretion",
         "Venomous Strike"
       ],
-      "heroic": "Coagulation  [Pulso de 3″]\nLos modelos oponentes dentro de este pulso que tengan la condición de Poison reciben 3 DAÑO de condición.",
+      "heroic": "Coagulation [Pulso de 3″]\nLos modelos enemigos dentro de este pulso que tengan la condición de Poison reciben 3 DAÑO de condición.",
       "types": "Valentian, Humano, Hombre, \nEnganche,\nSeguidor",
       "playbook": [
         [
@@ -1180,7 +1180,7 @@
       "character_traits": [
         "I've Been Burnt Before..."
       ],
-      "heroic": "Face Your Fear [Pulso de 4″]\nLos modelos oponentes dentro de este pulso reciben la condición de Burning.",
+      "heroic": "Face Your Fear [Pulso de 4″]\nLos modelos enemigos dentro de este pulso reciben la condición de Burning.",
       "types": "Skaldic, Humano, Mujer, \nDelantero,\nSeguidor",
       "playbook": [
         [
@@ -1339,7 +1339,7 @@
         "Reduction",
         "Reinforced Plating [1″ Aura]"
       ],
-      "legendary": "Covering Fire\nEste modelo puede usar una Character Play una vez por turno sin gastar influencia.\n\nSi este modelo es el Capitán, Revestimiento reforzado se transforma en una aura de 6″ y puede ser utilizado dos veces en vez de una",
+      "legendary": "Covering Fire\nEste modelo puede usar una Character Play una vez durante su activación sin gastar influencia.\n\nSi este modelo es el Capitán, Reinforced Plating se transforma en una aura de 6″ y puede ser utilizado dos veces en vez de una.",
       "types": "Numasai, Humano, Hombre, \nZaguero,\nMaestro, Seguidor",
       "playbook": [
         [
@@ -1391,7 +1391,7 @@
       "character_traits": [
         "Quench [1″ Aura]"
       ],
-      "legendary": "Batten Down The Hatches [Pulso de 6″]\nLos modelos aliados dentro de este pulso puden quitarse todas las condiciones que tengan.\n\nSi este modelo es el Capitán, los modelos aliados dentro de este pulso puede sanar 3 PS,",
+      "legendary": "Batten Down The Hatches [Pulso de 6″]\nLos modelos aliados dentro de este pulso pueden quitarse todas las condiciones que tengan.\n\nSi este modelo es el Capitán, los modelos aliados dentro de este pulso pueden sanar 3 PS.",
       "types": "Sultarish, Humano, Mujer, \nArquero,\nMaestro, Seguidor",
       "playbook": [
         [
@@ -1550,7 +1550,7 @@
         "Searing Strike",
         "Sentinel [1″ Aura]"
       ],
-      "legendary": "Tempered Steel [Aura de 6″] \nEste modelo obtiene +1 TAC.\n\nSi este modelo es el Capitán, los demás modelos aliados dentro de esta aura obtienen +1 TAC y Ataque agobiante.",
+      "legendary": "Tempered Steel [Aura de 6″]\nEste modelo obtiene +1 TAC.\n\nSi este modelo es el Capitán, los demás modelos aliados dentro de esta aura obtienen +1 TAC y Searing Strike.",
       "types": "Piert, Humano, Hombre, \nArmador,\nMaestro, Seguidor",
       "playbook": [
         [
@@ -1603,7 +1603,7 @@
         "Match Experience [4″ Aura]",
         "Sturdy"
       ],
-      "legendary": "Armoury  [Aura de 6″] \nLa Melee Zone de este modelo pasa a ser de 3″.\n\nSi este modelo es el Capitán, puede usar Capacitación tres veces durante su activación sin usar influencia, y los demás modelos aliados dentro de esta aura pasan a tener Melee Zone de 2″.",
+      "legendary": "Armoury [Aura de 6″]\nLa Melee Zone de este modelo pasa a ser de 3″.\n\nSi este modelo es el Capitán, puede usar Instruction tres veces durante su activación sin usar influencia, y los demás modelos aliados dentro de esta aura pasan a tener Melee Zone de 2″.",
       "types": "Skald, Humano, Mujer, \nVolante,\nMaestro, Seguidor",
       "playbook": [
         [
@@ -2075,7 +2075,7 @@
       "character_traits": [
         "Tough Hide"
       ],
-      "heroic": "Old Jake's\naloca 2 influencias a otros modelos aliados dentro de 8″.",
+      "heroic": "Old Jake's\nAloca 2 influencias a otros modelos aliados del gremio dentro de 8″.",
       "types": "Mald, Humano, Hombre, \nArmador,\nCapitán",
       "playbook": [
         [
@@ -2338,7 +2338,7 @@
         "Tough Hide"
       ],
       "heroic": "Duellist's Lunge\nCuando este modelo haga un ataque con éxito, puede hacer un Dodge de 1″ directamente hacia el objetivo del ataque.",
-      "types": "Erskirii, Humano, Mujer, \nEnganche,\nVeteranoo, Seguidor",
+      "types": "Erskirii, Humano, Mujer, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           null,
@@ -2464,7 +2464,7 @@
           null
         ]
       ],
-      "heroic": "Sliding Tackle\nCuando este modelo cargue, adempas de los resultados de la Playbook, el modelo cargado recibe la condición de Knocked Down."
+      "heroic": "Sliding Tackle\nCuando este modelo cargue, además de los resultados de la Playbook, el modelo enemigo objetivo recibe la condición de Knocked Down."
     },
     {
       "id": "Hooper",
@@ -2548,7 +2548,7 @@
         "Resilience",
         "Tough Hide"
       ],
-      "heroic": "Batter Up\nUna vez durante la activación de este modelo, este modelo puedo hacer un paso sin gastar influencia.\nEl pase gana +0/+4″ KICK",
+      "heroic": "Batter Up\nUna vez durante la activación de este modelo, este modelo puede hacer un pase sin gastar influencia.\nEl pase gana +0/+4″ KICK.",
       "types": "Eisnoran, Humano, Hombre, \nEnganche,\nSeguidor",
       "playbook": [
         [
@@ -2602,7 +2602,7 @@
         "Six Pack",
         "Taunt"
       ],
-      "heroic": "Come On, Then!\nLa próxima vez que este modelo vaya a ser impactado por un ataque o Character Play, antes de activar cualquier otra habilidad, el ataque o Character Playse considera fallada y el impacto es ignorado.",
+      "heroic": "Come On, Then!\nLa próxima vez que este modelo vaya a ser impactado por un ataque o Character Play, antes de activar cualquier otra habilidad, el ataque o Character Play se considera fallada y el impacto es ignorado.",
       "types": "Mald, Humano, Hombre, \nArmador,\nSeguidor",
       "playbook": [
         [
@@ -2654,7 +2654,7 @@
         "Floored",
         "Tough Hide"
       ],
-      "heroic": "Time's Called[Aura de 4″]\nCuando un modelo aliado empieza un avance dentro de esta aura, obtiene +2″ /+2″ MOV.",
+      "heroic": "Time's Called [Aura de 4″]\nCuando un modelo aliado del gremio empieza un avance dentro de esta aura, obtiene +2″/+2″ MOV.",
       "types": "Raed, Humano, Hombre, \nZaguero,\nSeguidor",
       "playbook": [
         [
@@ -2708,7 +2708,7 @@
         "Football Legend [4″ Aura]"
       ],
       "heroic": "Back to His Best\nEste modelo obtiene +2″ /+2″ MOV. Una vez por turno durante su activación, este modelo puede hacer un pase sin gastar influencia.",
-      "types": "Raed, Humano, Hombre, \nDelantero,\nVeteranoo, Seguidor",
+      "types": "Raed, Humano, Hombre, \nDelantero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -2759,7 +2759,7 @@
         "Battering Ram",
         "Tough Hide"
       ],
-      "heroic": "Explosive Brew\nDurante su activación, este modelo puede utilizar Arrojar barril sin gastar influencia.",
+      "heroic": "Explosive Brew\nDurante su activación, este modelo puede utilizar Lob Barrel sin gastar influencia.",
       "types": "Mald, Humano, Hombre, \nVolante,\nSeguidor",
       "playbook": [
         [
@@ -2813,7 +2813,7 @@
         "Magical Brew",
         "Searing Strike"
       ],
-      "heroic": "Human Ball of Fire\nEste modelo obtiene +1″ /+1″ MOV. Durante los avances de este modelo, los modelos oponentes que entre en contacto base con base con este modelo reciben la condición de Burning.",
+      "heroic": "Human Ball of Fire\nEste modelo obtiene +1″/+1″ MOV. Durante los avances de este modelo, los modelos que entren en contacto base con base con este modelo reciben la condición de Burning.",
       "types": "Eisnoran, Humano, Hombre, \nZaguero,\nSeguidor",
       "playbook": [
         [
@@ -2866,7 +2866,7 @@
         "Stack the Deck",
         "Tough Hide"
       ],
-      "heroic": "Raise the Stakes\nEste modelo puedo hacer un Dodge de 4″. Después de resolver\nesta esquiva, el jugador oponente puede elegir otro\n modelo Seguidor que controle para que reciba un Push de 2″.",
+      "heroic": "Raise the Stakes\nEste modelo puede hacer un Dodge de 4″. Después de resolver este Dodge, el jugador enemigo puede elegir otro modelo Seguidor que controle para que reciba un Push de 2″.",
       "types": "Valentian, Humano, Hombre, \nArmador,\nSeguidor",
       "playbook": [
         [
@@ -2918,7 +2918,7 @@
       "character_traits": [
         "The Owner [6″ Aura]"
       ],
-      "legendary": "Get 'Em Lads! [Aura de 6″] \nLos modelos aliados dentro de esta aura obtienen +1 DAÑO a Character Plays que causan damage y resultados de damage de la Playbook.\nLos modelos oponentes dentro de esta aura reciben -1 ARM.",
+      "legendary": "Get 'Em Lads! [Aura de 6″]\nLos modelos aliados del gremio dentro de esta aura obtienen +1 DAÑO a Character Plays que causan daño y resultados de daño de la Playbook.\nLos modelos enemigos dentro de esta aura reciben -1 ARM.",
       "types": "Skaldic, Humano, Hombre, \nEnganche,\nCapitán",
       "playbook": [
         [
@@ -2972,7 +2972,7 @@
         "Haemophilia [6″ Aura]",
         "Smell Blood"
       ],
-      "legendary": "Exsanguinate  [Pulso de 6″]\nLos modelos oponentes dentro de este pulso que tengan la condición de Bleed reciben 3 DAÑO de condición",
+      "legendary": "Exsanguinate [Pulso de 6″]\nLos modelos enemigos dentro de este pulso que tengan la condición de Bleed reciben 3 DAÑO de condición.",
       "types": "Valentian, Humano, Mujer, \nDelantero,\nCapitán",
       "playbook": [
         [
@@ -3026,8 +3026,8 @@
         "Blood Lust [6″ Aura]",
         "Furious"
       ],
-      "legendary": "Chop Chop! [Aura de 6″] \nLos demás modelos aliados dentro de esta aura ganan Furioso.",
-      "types": "Skaldic, Humano, Hombre, \nEnganche,\nVeteranoo, Capitán",
+      "legendary": "Chop Chop! [Aura de 6″]\nLos demás modelos aliados dentro de esta aura ganan Furious.",
+      "types": "Skaldic, Humano, Hombre, \nEnganche,\nVeterano, Capitán",
       "playbook": [
         [
           ">",
@@ -3340,7 +3340,7 @@
         "Pragmatic",
         "Unpredictable Movement"
       ],
-      "types": "Valentian, Humano, Mujer, \nPuntero,\nVeteranoo, Seguidor",
+      "types": "Valentian, Humano, Mujer, \nPuntero,\nVeterano, Seguidor",
       "playbook": [
         [
           "T",
@@ -3392,7 +3392,7 @@
         "Crucial Artery",
         "Sweeping Charge"
       ],
-      "types": "Erskirii, Humano, Mujer, \nArmador,\nVeteranoo, Seguidor",
+      "types": "Erskirii, Humano, Mujer, \nArmador,\nVeterano, Seguidor",
       "playbook": [
         [
           null,
@@ -3496,7 +3496,7 @@
       "character_traits": [
         "Hooked"
       ],
-      "heroic": "Sanguine Pool [Pulso de 3″]\nLos modelos oponentes dentro de este pulso que tengan la condición de Bleed obtienen -4″ /-4″ MOV.",
+      "heroic": "Sanguine Pool [Pulso de 3″]\nLos modelos enemigos dentro de este pulso que tengan la condición de Bleed obtienen -4″ /-4″ MOV.",
       "types": "Erskirii, Humano, Mujer, \nEnganche,\nSeguidor",
       "playbook": [
         [
@@ -3549,7 +3549,7 @@
         "Rowdy",
         "The Old Ways"
       ],
-      "types": "Skaldic, Humano, Hombre, \nEnganche,\nVeteranoo, Seguidor",
+      "types": "Skaldic, Humano, Hombre, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           null,
@@ -4024,9 +4024,9 @@
       "character_traits": [
         "If You Can Dodge a Wrench...",
         "Inspiring Hat [4″ Aura]",
-        "Learn From The Best [Capitán]"
+        "Learn From The Best [Captain]"
       ],
-      "types": "Ethraynnian, Humano, Mujer, \nZaguero,\nVeteranoo, Seguidor",
+      "types": "Ethraynnian, Humano, Mujer, \nZaguero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -4076,7 +4076,7 @@
         "Sturdy",
         "True Replication [6″ Aura]"
       ],
-      "heroic": "Locked & Loaded\nUna vez durante su activación, este modelo puedo usar una Character Playsin gastar influencia.",
+      "heroic": "Locked & Loaded\nUna vez durante su activación, este modelo puede usar una Character Play sin gastar influencia.",
       "types": "Erskirii, Mechanica,\nEnganche,\nSeguidor",
       "playbook": [
         [
@@ -4183,7 +4183,7 @@
         "Roulette",
         "Unpredictable Movement"
       ],
-      "legendary": "Wherever I May Roam\nElegí un elemento de escenografía dentro de 4″. Este modelo es inmediatamente posicionado en contacto base con base con dicho elemento de escenografía.",
+      "legendary": "Wherever I May Roam\nElige un elemento de escenografía dentro de 4″. Este modelo es inmediatamente posicionado en contacto base con base con dicho elemento de escenografía.",
       "types": "Raed, Humano, Hombre, \nPuntero,\nSeguidor",
       "playbook": [
         [
@@ -4236,7 +4236,7 @@
       "character_traits": [
         "Fixer"
       ],
-      "heroic": "Overclocked\nElegín un modelo Mechanica dentro de 4″. Durante su proxima activación, el modelo elegido puede hacer un Sprint o cargar sin gastar influencia.",
+      "heroic": "Overclocked\nElige un modelo Mechanica dentro de 4″. Durante su próxima activación, el modelo elegido puede hacer un Sprint o cargar sin gastar influencia.",
       "types": "Indar, Humano, Hombre, \nZaguero,\nSeguidor",
       "playbook": [
         [
@@ -4290,7 +4290,7 @@
       "character_traits": [
         "Swift Strikes"
       ],
-      "heroic": "Locked & Loaded\nUna vez durante su activación, este modelo puede usar una Character Playsin gastar influencia.",
+      "heroic": "Locked & Loaded\nUna vez durante su activación, este modelo puede usar una Character Play sin gastar influencia.",
       "types": "Ethraynnian, Humano, Hombre, \nPuntero,\nSeguidor",
       "playbook": [
         [
@@ -4394,7 +4394,7 @@
         "Lend a Hand",
         "Reanimate"
       ],
-      "types": "Ethraynnian, Mechanica,\nDelantero,\nVeteranoo, Seguidor",
+      "types": "Ethraynnian, Mechanica,\nDelantero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -4499,7 +4499,7 @@
         "For the Family [4″ Aura]",
         "Planting Master"
       ],
-      "legendary": "Huge Tracts of Land[Aura de 6″] \nEste modelo puede inmediatamente colocar hasta dos marcadores de cosecha alidados dentro de esta aura. Mientras estén dentro de esta aura, los modelos aliados obtienen Sturdy.\n{{trait 'Sturdy'}}",
+      "legendary": "Huge Tracts of Land [Aura de 6″]\nEste modelo puede inmediatamente colocar hasta dos marcadores de cosecha aliados dentro de esta aura. Mientras estén dentro de esta aura, los modelos aliados del gremio obtienen Sturdy.\n{{trait 'Sturdy'}}",
       "types": "Piert, Humano, Hombre, \nZaguero,\nSembrador, Capitán",
       "playbook": [
         [
@@ -4553,7 +4553,7 @@
         "Harvest Supper",
         "Planting Master"
       ],
-      "legendary": "Line Dancing [Pulso de 6″]\nElegí un borde la de cancha. Los modelos aliados dentro de este pulso reciben un Push´de 5″ directamente hacia el borde elegido.",
+      "legendary": "Line Dancing [Pulso de 6″]\nElige un borde de la cancha. Los modelos aliados dentro de este pulso reciben un Push de 5″ directamente hacia el borde elegido.",
       "types": "Piert, Humano, Mujer, \nD.T.,\nSembrador, Capitán",
       "playbook": [
         [
@@ -4919,7 +4919,7 @@
         "Fields of Wheat [4″ Aura]",
         "Planting Season"
       ],
-      "heroic": "Surpassing Strategy\nEl modelo aliado objetivo que no sea capitán dentro de 4″ gana Protectora fiel. Ese modelo puede inmediatamente hacer un Dodge de 4″.",
+      "heroic": "Surpassing Strategy\nEl modelo aliado objetivo que no sea Capitán dentro de 4″ gana Faithful Protector. Ese modelo puede inmediatamente hacer un Dodge de 4″.",
       "types": "Castellyian, Humano, Mujer, \nD.T.,\nSembrador, Veterano, Seguidor",
       "playbook": [
         [
@@ -5233,7 +5233,7 @@
         "Light Footed",
         "Showboater"
       ],
-      "legendary": "Caught in a Net [Pulso de 6″]\nLos modelos oponentes dentro de este pulso reciben -4″ /-4″ MOV.",
+      "legendary": "Caught in a Net [Pulso de 6″]\nLos modelos enemigos dentro de este pulso reciben -4″ /-4″ MOV.",
       "types": "Eisnoran, Humano, Hombre, \nDelantero,\nCapitán",
       "playbook": [
         [
@@ -5287,7 +5287,7 @@
         "Sturdy",
         "Tough Hide"
       ],
-      "legendary": "Hook, Line, and Sinker [Pulso de 6″]\nLos modelos oponentes dentro de este pulso reciben un Push de 6″ directamente hacia este modelo.",
+      "legendary": "Hook, Line, and Sinker [Pulso de 6″]\nLos modelos enemigos dentro de este pulso reciben un Push de 6″ directamente hacia este modelo.",
       "types": "Indar, Humano, Hombre, \nZaguero,\nCapitán",
       "playbook": [
         [
@@ -5340,7 +5340,7 @@
         "Last Cast Catches the Most",
         "Beating Wings Over Water"
       ],
-      "legendary": "Cormorant’s Calling\nElige un modelo dentro de 10″ de este modelo que no esté trabado en combate. Coloca el modelo elegido dentro de 10″ de este modelo.",
+      "legendary": "Cormorant's Calling\nElige otro modelo aliado dentro de 10″ de este modelo que no esté trabado en combate. Coloca el modelo elegido dentro de 10″ de este modelo.",
       "types": "Numasai, Humano,\nD.T.,\nCapitán",
       "playbook": [
         [
@@ -5603,7 +5603,7 @@
         "Shadow Like",
         "Talisman"
       ],
-      "legendary": "Call of the Sea [Pulso de 4″]\nEste modelo recibe 1 DAÑO por cado otro modelo en este pulso. Los modelos oponentes dentro de este pulso reciben un Push de 2″.Los demás modelos aliados dentro de este pulsopuede hacer un Dodge de 2″.",
+      "legendary": "Call of the Sea [Pulso de 4″]\nEste modelo recibe 1 DAÑO por cada otro modelo en este pulso. Los modelos enemigos dentro de este pulso reciben un Push de 2″. Los demás modelos aliados dentro de este pulso pueden hacer un Dodge de 2″.",
       "types": "Numasai, Humano, Mujer, \nArmador,\nSeguidor",
       "playbook": [
         [
@@ -5866,7 +5866,7 @@
         "Anatomical Precision",
         "Bag of Coffers"
       ],
-      "types": "Numasai, Humano, Hombre, \nEnganche,\nVeteranoo, Seguidor",
+      "types": "Numasai, Humano, Hombre, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -5971,7 +5971,7 @@
         "Escaping Fate",
         "Shadow Like"
       ],
-      "types": "Desconocido, Humano, Mujer, \nEnganche,\nVeteranoo, Seguidor",
+      "types": "Desconocido, Humano, Mujer, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -6025,7 +6025,7 @@
         "Light Footed",
         "Nature's Growth"
       ],
-      "heroic": "Blessing of the Sun Father\nUna vez durante su activación, un modelo aliado Delantero de 6″ puede usar una Character Playsin gastar influencia.",
+      "heroic": "Blessing of the Sun Father\nUna vez durante su activación, el modelo aliado objetivo dentro de 6″ puede usar una Character Play sin gastar influencia.",
       "types": "Raed, Humano, Hombre, \nZaguero,\nCapitán",
       "playbook": [
         [
@@ -6133,7 +6133,7 @@
         "Bring Them Down",
         "Expert Trapper"
       ],
-      "legendary": "Perfect Positioning [Pulso de 6″]\neEte modelo puede colocar hasta 5 marcadores de trampa aliados dentro de este pulso.",
+      "legendary": "Perfect Positioning [Pulso de 6″]\nEste modelo puede colocar hasta 5 marcadores de trampa aliados dentro de este pulso.",
       "types": "Indar, Humano, Mujer, \nEnganche,\nCapitán",
       "playbook": [
         [
@@ -6450,7 +6450,7 @@
         "Light Footed",
         "Nature's Blessing"
       ],
-      "heroic": "Blessing of the Sun Father\nUna vez durante su activación, un modelo aliado Delantero de 6″ puede usar una Character Playsin gastar influencia.",
+      "heroic": "Blessing of the Sun Father\nUna vez durante su activación, el modelo aliado objetivo dentro de 6″ puede usar una Character Play sin gastar influencia.",
       "types": "Desconocido, Humano, Hombre, \nVolante,\nSeguidor",
       "playbook": [
         [
@@ -6504,7 +6504,7 @@
         "Lunar Eclipse",
         "Winter's Blessing"
       ],
-      "types": "Desconocido, Humano, Hombre, \nVolante,\nVeteranoo, Seguidor",
+      "types": "Desconocido, Humano, Hombre, \nVolante,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -6609,8 +6609,8 @@
         "Big Game Traps",
         "Heightened Senses"
       ],
-      "heroic": "Blessing of the Sun Father\nUna vez durante su activación, un modelo aliado Delantero de 6″ puede usar una Character Playsin gastar influencia.",
-      "types": "Desconocido, Mujer, \nEnganche,\nVeteranoo, Seguidor",
+      "heroic": "Blessing of the Sun Father\nUna vez durante su activación, el modelo aliado objetivo dentro de 6″ puede usar una Character Play sin gastar influencia.",
+      "types": "Desconocido, Mujer, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -6767,7 +6767,7 @@
         "Linked [Fahad, Snow]",
         "Unpredictable Movement"
       ],
-      "legendary": "The Power of Voodoo\nEl modelo aliado dentro de 6″ puede inmediatamente hacer un trote.",
+      "legendary": "The Power of Voodoo\nEl modelo aliado dentro de 6″ puede inmediatamente hacer un Jog.",
       "types": "Eisnoran, Humano, Mujer, \nPuntero,\nSeguidor",
       "playbook": [
         [
@@ -6821,7 +6821,7 @@
         "Linked [Harmony]",
         "Poised"
       ],
-      "legendary": "Topping Out! [Pulso de 6″]\nElegí un efecto:\n- Los modelos aliados dentro de este pulso obtienen +1 ARM\n- Cada modelo aliado dentro de este pulso es alocado 1 influencia",
+      "legendary": "Topping Out! [Pulso de 6″]\nElige un efecto:\n- Los modelos aliados dentro de este pulso obtienen +1 ARM.\n- Cada modelo aliado dentro de este pulso es alocado 1 influencia.",
       "types": "Castellyian, Humano, Mujer, \nArmador,\nCapitán",
       "playbook": [
         [
@@ -6876,7 +6876,7 @@
         "Repointing [6″ Aura]",
         "Tough Hide"
       ],
-      "legendary": "Hammer Time! [Pulso de 6″]\nCada modelo aliado dentro del pulso puede elegir uno de los siguientes beneficios:\n- +2″ /+2″ MOV\n- +1 DAÑO a los resultados de daño de la Playbook",
+      "legendary": "Hammer Time! [Pulso de 6″]\nCada otro modelo aliado dentro del pulso puede elegir uno de los siguientes beneficios:\n- +2″/+2″ MOV\n- +1 DAÑO a los resultados de daño de la Playbook.",
       "types": "Raed, Humano, Hombre, \nEnganche,\nCapitán",
       "playbook": [
         [
@@ -6930,7 +6930,7 @@
         "Close Control",
         "Making Space"
       ],
-      "legendary": "Playing the Game\nElegí una pelota suelta dentro de 6″ de este modelo. Este modelo inmediatamente gana posesión de la pelota suelta.",
+      "legendary": "Playing the Game\nElige una pelota suelta dentro de 6″ de este modelo. Este modelo inmediatamente gana posesión de la pelota suelta.",
       "types": "Figeon, Humano, Hombre, \nDelantero,\nCapitán",
       "playbook": [
         [
@@ -7187,7 +7187,7 @@
       "character_traits": [
         "Revelling"
       ],
-      "heroic": "Intensity\nUna vez durante su activación, este modelo puede use una Character Playsin gastar influencia.",
+      "heroic": "Intensity\nUna vez durante su activación, este modelo puede usar una Character Play sin gastar influencia.",
       "types": "Valentian, Humano, Mujer, \nEnganche,\nSeguidor",
       "playbook": [
         [
@@ -7239,7 +7239,7 @@
         "Adaptive Strategy [6″ Pulse]",
         "Take One for the Team [6″ Aura]"
       ],
-      "types": "Valentian, Humano, Mujer, \nZaguero,\nVeteranoo, Seguidor",
+      "types": "Valentian, Humano, Mujer, \nZaguero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -7448,7 +7448,7 @@
         "Field Medic [4″ Aura]",
         "Team Player [4″ Aura]"
       ],
-      "types": "Castellyian, Humano, Mujer, \nEnganche,\nVeteranoo, Seguidor",
+      "types": "Castellyian, Humano, Mujer, \nEnganche,\nVeterano, Seguidor",
       "playbook": [
         [
           "T",
@@ -7607,7 +7607,7 @@
         "Shadow Like",
         "Unpredictable Movement"
       ],
-      "legendary": "Rigor Mortis\nEl equipo oponente pierde todo su MP, y el equipo aliado gana una cantidad de MP igual a la cantidad perdida por el equipo oponente.",
+      "legendary": "Rigor Mortis\nEl equipo enemigo pierde todo su MP, y el equipo aliado gana una cantidad de MP igual a la cantidad perdida por el equipo enemigo.",
       "types": "Figeon, Humano, Hombre, \nZaguero,\nCapitán",
       "playbook": [
         [
@@ -7681,7 +7681,7 @@
           "4"
         ]
       ],
-      "heroic": "Vulnerable Prey\nLos próxima vez que este modelo cause  daño de Playbook en un modelo oponente que no esté dentro de 5″ de ningún otro modelo oponente, el modelo oponente recibe 3 DMG adicionales"
+      "heroic": "Vulnerable Prey\nLa próxima vez que este modelo cause daño de Playbook en un modelo enemigo que no esté dentro de 5″ de ningún otro modelo enemigo, el modelo enemigo recibe 3 DAÑO adicionales."
     },
     {
       "id": "Mourn",
@@ -7872,7 +7872,7 @@
         "Stamina",
         "Wraith Walk"
       ],
-      "heroic": "Grave Wind\nLa próxima vez que este modelo empuje a un modelo oponente, el modelo oponente revibe la condición derribado .",
+      "heroic": "Grave Wind\nLa próxima vez que este modelo haga un Push a un modelo enemigo, el modelo enemigo recibe la condición de Knocked Down.",
       "types": "Piert, Humano, Hombre, \nDelantero,\nSeguidor",
       "playbook": [
         [
@@ -8031,7 +8031,7 @@
         "Reanimate",
         "Tough Hide"
       ],
-      "legendary": "Casket Time\nLa próxima vez que este modelo cause que un modelo Humano oponente reciba la condición noqueado, el equipo aliados recibe 2 PV adicionales. Además, el modelo noqueado no puede volver a la cancha durante la próxima fase de mantenimiento.",
+      "legendary": "Casket Time\nLa próxima vez que este modelo cause que un modelo Humano enemigo reciba la condición de Taken Out, el equipo aliado recibe 2 VP adicionales. Además, el modelo con Taken Out no puede volver a la cancha durante la próxima fase de mantenimiento.",
       "types": "Piert, Humano, Hombre, \nVolante,\nSeguidor",
       "playbook": [
         [
@@ -8136,7 +8136,7 @@
       "character_traits": [
         "The Knowledge"
       ],
-      "legendary": "Handy Listener, Such As You Are\nremueve la cantidad de marcadores de susurro que quieras de modelos oponentesque estén en la cancha. Por cada marcador de susurro removido de esta forma, pon un marcador de susurro en un modelo oponente en la cancha.",
+      "legendary": "Handy Listener, Such As You Are\nRemueve la cantidad de marcadores de susurro que quieras de modelos enemigos que estén en la cancha. Por cada marcador de susurro removido de esta forma, pon un marcador de susurro en un modelo enemigo en la cancha.",
       "types": "Piert, Humano, Hombre, \nD.T.,\nSeguidor",
       "playbook": [
         [
@@ -8240,7 +8240,7 @@
         "Brutal",
         "Finisher"
       ],
-      "heroic": "Tainted Wounds\nLos modelos oponentes dentro de la Melee Zone no puede curarse HP.",
+      "heroic": "Tainted Wounds\nLos modelos enemigos dentro de la Melee Zone no pueden curarse HP.",
       "types": "Raed, Humano, Hombre, \nPuntero,\nSeguidor",
       "playbook": [
         [
@@ -8292,8 +8292,8 @@
         "They Ain't Tough!"
       ],
       "character_traits": [],
-      "heroic": "Packmaster  [Squeak, Vileswarm]\nEl modelo aliado mencionado objetivo dentro de 4″ es alocado 2 influencias.",
-      "types": "Raed, Humano, Hombre, \nZaguero,\nVeteranoo, Seguidor",
+      "heroic": "Packmaster [Squeak, Vileswarm]\nEl modelo aliado mencionado objetivo dentro de 4″ es alocado 2 influencias.",
+      "types": "Raed, Humano, Hombre, \nZaguero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -8345,8 +8345,8 @@
         "Dark Doubts",
         "Soul Seer"
       ],
-      "legendary": "The Power of Voodoo\nEl modelo aliado dentro de 6″ puede inmediatamente hacer un trote.",
-      "types": "Eisnoran, Humano, Mujer, \nZaguero,\nVeteranoo, Seguidor",
+      "legendary": "The Power of Voodoo\nEl modelo aliado dentro de 6″ puede inmediatamente hacer un Jog.",
+      "types": "Eisnoran, Humano, Mujer, \nZaguero,\nVeterano, Seguidor",
       "playbook": [
         [
           "1",
@@ -8451,7 +8451,7 @@
       "character_traits": [
         "Shadow Like"
       ],
-      "legendary": "Strike from the Shadows [Pulso de 6″]\nElegí un afecto:\n- Los modelos aliados dentro de este pulso obtienen +1 DEF.\n- Los modelos aliados dentro de este pulso hacen un Dodge de 2″.",
+      "legendary": "Strike from the Shadows [Pulso de 6″]\nElige un efecto:\n- Los modelos aliados dentro de este pulso obtienen +1 DEF.\n- Los modelos aliados dentro de este pulso hacen un Dodge de 2″.",
       "types": "Sultarish, Humano, Hombre, \nArmador,\nCapitán",
       "playbook": [
         [
@@ -8505,8 +8505,8 @@
         "Furious",
         "Rising Anger"
       ],
-      "heroic": "Bloody Coin\nEl modelo aliado a 4″ obtiene +1 TAC y +1 DAÑO a los resultados de daño de la Playbook cuando ataquen a un modelo que este trabado en combate por otro modelo aliado",
-      "legendary": "My Gang [Aura de 6″] \nLos modelos aliados dentro de esta aura obtienen +1 TAC y +1 DAÑO de daño de la Playbook cuando ataquen a un modelo que este trabado en combate por otro modelo aliado.\nMy gente no se acumula con Dinero sucio.",
+      "heroic": "Bloody Coin\nEl modelo aliado a 4″ obtiene +1 TAC y +1 DAÑO a los resultados de daño de la Playbook cuando ataquen a un modelo que este trabado en combate por otro modelo aliado.",
+      "legendary": "My Gang [Aura de 6″]\nLos modelos aliados dentro de esta aura obtienen +1 TAC y +1 DAÑO a los resultados de daño de la Playbook cuando ataquen a un modelo que esté trabado en combate por otro modelo aliado.\nMy Gang no se acumula con Bloody Coin.",
       "types": "Castellyian, Humano, Hombre, \nEnganche,\nCapitán, Veterano",
       "playbook": [
         [
@@ -8872,7 +8872,7 @@
         "Foul Odour [3″ Aura]",
         "Resilience"
       ],
-      "heroic": "Fangtooth Unleashed\nEste modelo recibe 4 DAÑO y obtiene +2″ /+2″ MOV y +1 DAÑO a las Character Plays que causan daño y a los resultados de daño de la Playbook",
+      "heroic": "Fangtooth Unleashed\nEste modelo recibe 4 DAÑO y obtiene +2″ /+2″ MOV y +1 DAÑO a las Character Plays que causan daño y a los resultados de daño de la Playbook.",
       "types": "Ethraynnian, Humano, Hombre, \nVolante,\nSeguidor",
       "playbook": [
         [
@@ -9084,7 +9084,7 @@
         "Crucial Artery",
         "Furious"
       ],
-      "heroic": "Intensity\nUna vez durante su activación, este modelo puede usar una Character Playsin gastar influencia.",
+      "heroic": "Intensity\nUna vez durante su activación, este modelo puede usar una Character Play sin gastar influencia.",
       "types": "Castellyian, Humano, Hombre, \nEnganche,\nSeguidor",
       "playbook": [
         [
@@ -9509,7 +9509,7 @@
         "Assist [Frelsi]",
         "Death from Above"
       ],
-      "legendary": "Daughter of Falcons [Pulso de 6″]\nLos modelos oponentes dentro de este pulso reciben 3 DAÑO y la condición de atrapado.",
+      "legendary": "Daughter of Falcons [Pulso de 6″]\nLos modelos enemigos dentro de este pulso reciben 3 DAÑO y la condición de Snared.",
       "types": "Figeon, Humano, Mujer, \nArmador,\nCapitán",
       "playbook": [
         [
@@ -9929,7 +9929,7 @@
         "Guild Rule: Secret Tunnel",
         "You're Coming With Me"
       ],
-      "legendary": "Tremor Mine\nElegí una pelota suelta dentro de 8″ de este modelo y sacala de la cancha. El controlador de este modelo resuelve un saque de arco.",
+      "legendary": "Tremor Mine\nElige una pelota suelta dentro de 8″ de este modelo y sácala de la cancha. El controlador de este modelo resuelve un saque de arco.",
       "types": "Numasai, Mechanica, Humano, Mujer, \nVolante,\nSeguidor",
       "playbook": [
         [
@@ -10143,7 +10143,7 @@
         "Guild Rule: Precise Calculations",
         "Stormwind"
       ],
-      "legendary": "Perfect Course [Pulso de 6″]\nPor cada modelo oponente en este pulso, un modelo aliado en este pulso puede hacer un Dodge de 4″. Cada modelo aliado puede moverse una sola vez por el efecto de Ruta perfecta.",
+      "legendary": "Perfect Course [Pulso de 6″]\nPor cada modelo enemigo en este pulso, un modelo aliado en este pulso puede hacer un Dodge de 4″. Cada modelo aliado puede moverse una sola vez por el efecto de Perfect Course.",
       "types": "Sultarish, Humano, Mujer, \nEnganche,\nCapitán",
       "playbook": [
         [
@@ -10465,7 +10465,7 @@
         "Scores for Fun",
         "Unpredictable Movement"
       ],
-      "legendary": "Worthy Sacrifice [Aura de 6″] \nColoca a este modelo en contacto peana con peana de otro modelo aliado a 6″. El otro modelo aliado puede hacer un Dodge de 6″.",
+      "legendary": "Worthy Sacrifice [Aura de 6″] \nColoca a este modelo en contacto base con base de otro modelo aliado a 6″. El otro modelo aliado puede hacer un Dodge de 6″.",
       "types": "Valentian, Humano, Mujer, \nDelantero,\nCapitán, Experimentado",
       "playbook": [
         [
@@ -10623,7 +10623,7 @@
         "Potbellied Pass",
         "Resilience"
       ],
-      "types": "Ethraynnian, Humano, Hombre, \nVolante,\nVeteranoo, Seguidor",
+      "types": "Ethraynnian, Humano, Hombre, \nVolante,\nVeterano, Seguidor",
       "playbook": [
         [
           null,
@@ -10835,7 +10835,7 @@
         "Close Control",
         "Floored"
       ],
-      "heroic": "Leyendo la cancha\nEl modelo aliado objetivo dnetro de 6″ puede inmediatamente hacer un pasesin gastar influencia.",
+      "heroic": "Leyendo la cancha\nEl modelo aliado objetivo dentro de 6″ puede inmediatamente hacer un pase sin gastar influencia.",
       "types": "Raed, Humano, Hombre, \nEnganche,\nSeasoned, Seguidor",
       "playbook": [
         [
@@ -10887,8 +10887,8 @@
       "character_traits": [
         "Haunting Melody"
       ],
-      "heroic": "Distracting Tune\nElegí un modelo oponente dentro de 4″. El modelo elegido sufre un Push de 2″.",
-      "legendary": "Swarm’s Obedience [8″ Pulse]\nElegí el arco aliado o enemigo. Los modelos dentro del pulso reciben un Push de 3″ directamente hacia el arco elegido.",
+      "heroic": "Distracting Tune\nElige un modelo enemigo dentro de 4″. El modelo elegido sufre un Push de 2″.",
+      "legendary": "Swarm's Obedience [Pulso de 8″]\nElige el arco aliado o enemigo. Los modelos dentro del pulso reciben un Push de 3″ directamente hacia el arco elegido.",
       "types": "Mald, Humano, Hombre, \nDelantero,\nCapitán",
       "playbook": [
         [
@@ -10940,7 +10940,7 @@
         "Predatory Instinct",
         "Tag Along"
       ],
-      "legendary": "The Rat King\nElegí una pelota suelta dentro de 8″ de este modelo y removela de la cancha. El jugador que controla a este modelo resuelve un saque de arco.",
+      "legendary": "The Rat King\nElige una pelota suelta dentro de 8″ de este modelo y remuévela de la cancha. El jugador que controla a este modelo resuelve un saque de arco.",
       "types": "Mald, Animal,\nMascota",
       "playbook": [
         [
@@ -11206,7 +11206,7 @@
         "Protect the Ball [6″ Pulse]",
         "Sheep Become the Shepherds"
       ],
-      "legendary": "Rest Up!\nElegí otro modelo aliado dentro de 4″. El modelo aliado recibe la condición de Knocked Out. El oponentes no recibe PV por este noqueo.",
+      "legendary": "Rest Up!\nElige otro modelo aliado dentro de 4″. El modelo aliado recibe la condición de Taken Out. El enemigo no recibe VP por este Taken Out.",
       "types": "Piert, Humano, Mujer, \nCosechador, Armador,\nCapitán",
       "playbook": [
         [
@@ -11582,7 +11582,7 @@
         "Blinded by the Light",
         "Flare Out"
       ],
-      "legendary": "Eternal Flame [Pulso de 6″]\nTodos los modelos dentro de este pulso reciben la condición de Burning.\nLos modelos oponentes dentro de este pulso reciben 3 DAÑO.",
+      "legendary": "Eternal Flame [Pulso de 6″]\nTodos los modelos dentro de este pulso reciben la condición de Burning.\nLos modelos enemigos dentro de este pulso reciben 3 DAÑO.",
       "types": "Valentian, Humano, Mujer, \nD.T.,\nCapitán",
       "playbook": [
         [
@@ -11901,7 +11901,7 @@
         "Bends... But Never Breaks",
         "Caber Toss"
       ],
-      "legendary": "Fell Swing [8″ Pulse]\nLos modelos aliados dentro de este pulso y dentro de 1″ de un Log Pile aliado puede hacer un ataque sin gastar influencia. Después, elegí 2 marcadores de leña en la cancha. Posiciona los marcadores de leña dentro de este pulso.",
+      "legendary": "Fell Swing [Pulso de 8″]\nLos modelos aliados dentro de este pulso y dentro de 1″ de un Log Pile aliado pueden hacer un ataque sin gastar influencia. Después, elige hasta 2 marcadores de leña en la cancha. Posiciona los marcadores de leña dentro de este pulso.",
       "types": "Skald, Humano, Mujer, \nZaguero,\nCapitán",
       "playbook": [
         [
@@ -12113,7 +12113,7 @@
       "character_traits": [
         "Matched Pair [Cut]"
       ],
-      "heroic": "It's Bucking Time!\nSi el modelo aliado Cut está dentro de 4″ de este modelo, Posiciona a CrossCut con todos sus HP en contacto base con base con este modelo o Cut. Después, remove toda la influencia de este modeo y de Cut y alocáselas a CrossCut. Después, retira este modelo y a Cut de la cancha. después, Reemplazá la carta de este modelo y de Cut por la carta de CrossCut.",
+      "heroic": "It's Bucking Time!\nSi el modelo aliado Cut está dentro de 4″ de este modelo, Posiciona a CrossCut con todos sus HP en contacto base con base con este modelo o Cut. Después, remueve toda la influencia de este modelo y de Cut y alócaselas a CrossCut. Después, retira este modelo y a Cut de la cancha. Después, reemplaza la carta de este modelo y de Cut por la carta de CrossCut.",
       "types": "Mald, Humano, Hombre, \nPuntero,\nSeguidor",
       "playbook": [
         [
@@ -12273,7 +12273,7 @@
         "Synchronised [Flint]",
         "Putting Out Fires"
       ],
-      "legendary": "This Should Be Overtime...\nElegí una Log Pile en la cancha y posicionalo a 4″ de este modelo.",
+      "legendary": "This Should Be Overtime...\nElige una Log Pile en la cancha y posiciónala a 4″ de este modelo.",
       "types": "Eisnoran, Humano, Hombre, \nPuntero,\nSeguidor",
       "playbook": [
         [
@@ -12308,7 +12308,7 @@
     },
     {
       "name": "Lure of Gold",
-      "text": "El modelo objetivo aliado puede hacer un Jog hacia este modelo.",
+      "text": "Otro modelo aliado del gremio objetivo puede hacer un Jog hacia este modelo.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": false,
@@ -12316,7 +12316,7 @@
     },
     {
       "name": "Chemical Breeze",
-      "text": "Elegí una opción:\n- Los modelos enemigos dentro de 3″ del modelo aliado objetivo reciben la condición de Burning.\n- Los modelos enemigos dentro de 3″ del modelo aliado objetivo reciben la condición de Poison.",
+      "text": "Elige una:\n- Los modelos enemigos dentro de 3″ del modelo aliado del gremio objetivo reciben la condición de Burning.\n- Los modelos enemigos dentro de 3″ del modelo aliado del gremio objetivo reciben la condición de Poison.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -12324,7 +12324,7 @@
     },
     {
       "name": "Infuse",
-      "text": "El modelo objetivo oponente que tenga la condición de Burning o Poison recibe 3 DAÑO de condición.",
+      "text": "El modelo enemigo objetivo que tenga la condición de Burning o Poison recibe 3 DAÑO de condición.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -12332,7 +12332,7 @@
     },
     {
       "name": "Smoke Bomb",
-      "text": "Posiciona una AOE duradera dentro del alcance.\nMientras que estén dentro del AdE, los modelos aliados ganan cobertura.",
+      "text": "Posiciona una AOE duradera dentro del alcance.\nMientras que estén dentro de esta AOE, los modelos ganan cobertura.",
       "CST": 1,
       "RNG": 4,
       "SUS": false,
@@ -12340,7 +12340,7 @@
     },
     {
       "name": "Nitro!",
-      "text": "Pulso de 6″. Los modelos aliados dnetro de este pulso pueden hacer cualquier cantidad de esquivas de 1″, hasta un total de 6″ entre todos los modelos aliados.",
+      "text": "Pulso de 6″. Los modelos aliados del gremio dentro de este pulso pueden hacer cualquier cantidad de Dodges de 1″, hasta un total de 6″ entre todos los modelos aliados del gremio.",
       "CST": 3,
       "RNG": "S",
       "SUS": false,
@@ -12348,7 +12348,7 @@
     },
     {
       "name": "Raging Fire",
-      "text": "El modelo objetivo aliado gana Inferno.\n{{trait 'Inferno'}}",
+      "text": "El modelo aliado del gremio objetivo obtiene Inferno.",
       "CST": 2,
       "RNG": 6,
       "SUS": true,
@@ -12356,7 +12356,7 @@
     },
     {
       "name": "Hypnosis",
-      "text": "La próxima vez que el modelo oponente objetivo gaste influencia para ralizar un ataque, carga o Character Play, el modelo oponente tiene que hastar una influencia adicional.",
+      "text": "La próxima vez que el modelo enemigo objetivo gaste influencia para realizar un ataque, carga o Character Play, el modelo enemigo tiene que gastar 1 influencia adicional.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": true,
@@ -12380,7 +12380,7 @@
     },
     {
       "name": "Sticky Bomb",
-      "text": "Posiciona una AOE duradera dentro del alcance.\nLos modelos oponentes impactados reciben -2″ /-2″ MOV y la condición de Poison.\nLos modelos entrando o que terminen su activación dentro de esta AOE reciben la condición de Poison.",
+      "text": "Posiciona una AOE duradera dentro del alcance.\nLos modelos enemigos impactados reciben -2″ /-2″ MOV y la condición de Poison.\nLos modelos entrando o que terminen su activación dentro de esta AOE reciben la condición de Poison.",
       "CST": "2,CP",
       "RNG": 4,
       "SUS": true,
@@ -12396,7 +12396,7 @@
     },
     {
       "name": "Great Balls of Fire",
-      "text": "El modelo objetivo oponente pierde la posesion de la pelota y este modelo la gana, y el modelo oponente recibe la condición de Burning.",
+      "text": "El modelo enemigo objetivo pierde la posesión de la pelota y este modelo la gana, y el modelo enemigo recibe la condición de Burning.",
       "CST": 2,
       "RNG": 4,
       "SUS": false,
@@ -12404,7 +12404,7 @@
     },
     {
       "name": "Chemical Ordnance",
-      "text": "Elegí la condición de Burning o Poison. El modelo oponente objetivo recibe 1 DAÑO de condición y la condición elegida.",
+      "text": "Elige la condición de Burning o Poison. El modelo enemigo objetivo recibe 1 DAÑO de condición y la condición elegida.",
       "CST": "CP",
       "RNG": 4,
       "SUS": false,
@@ -12412,7 +12412,7 @@
     },
     {
       "name": "Kill the Ball",
-      "text": "Sacá la pelota suelta objetivo de la cancha. El controlador de este modelo resuelve un saque de arco.",
+      "text": "Saca la pelota suelta objetivo de la cancha. El controlador de este modelo resuelve un saque de arco.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -12420,7 +12420,7 @@
     },
     {
       "name": "External Combustion",
-      "text": "El modelo oponente objetivo recibe un empujoón de 4″ alejándose directamente de este modelo y 3 DAÑO, y luego los modelos dentro de 3″ del modelo objetivo reciben la condición de Burning.",
+      "text": "El modelo enemigo objetivo recibe un Push de 4″ alejándose directamente de este modelo y 3 DAÑO, y luego los modelos dentro de 3″ del modelo objetivo reciben la condición de Burning.",
       "CST": "CP2",
       "RNG": "P",
       "SUS": false,
@@ -12444,7 +12444,7 @@
     },
     {
       "name": "Fire Ball",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO y la condición de Burning.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO y la condición de Burning.",
       "CST": "CP",
       "RNG": 6,
       "SUS": false,
@@ -12452,7 +12452,7 @@
     },
     {
       "name": "Acid Rain",
-      "text": "Pulso de 3″. Los modelos oponentes dentro de este pulso reciben la condición de Poison.",
+      "text": "Pulso de 3″. Los modelos enemigos dentro de este pulso reciben la condición de Poison.",
       "CST": "CP",
       "RNG": "S",
       "SUS": false,
@@ -12460,7 +12460,7 @@
     },
     {
       "name": "Clone",
-      "text": "La próxima vez que este modelo vaya a ser impactado por un ataque o Character Play, antes de activar cualquier otra habilidad, el ataque o Character Playse considera fallada y el impacto es ignorado.",
+      "text": "La próxima vez que este modelo vaya a ser impactado por un ataque o Character Play, antes de activar cualquier otra habilidad, el ataque o Character Play se considera fallada y el impacto es ignorado.",
       "CST": "2,CP",
       "RNG": "S",
       "SUS": true,
@@ -12468,7 +12468,7 @@
     },
     {
       "name": "Horrific Odour",
-      "text": "Aura de 6\n. Los modelos oponentes dentro de esta aura deben gastar 1 influencia más para hacer una Kick",
+      "text": "Aura de 6″. Los modelos enemigos dentro de esta aura deben gastar 1 influencia más para hacer una Kick.",
       "CST": 1,
       "RNG": "S",
       "SUS": true,
@@ -12484,7 +12484,7 @@
     },
     {
       "name": "While the Iron is Hot",
-      "text": "Pulso de 6″. Elegí el arco aliado u oponente. Los modelos aliados dentro de este pulso pueden hacer un Dodge de 2″ directamente hacia el arco elegido.",
+      "text": "Pulso de 6″. Elige el arco aliado o enemigo. Los modelos aliados dentro de este pulso pueden hacer un Dodge de 2″ directamente hacia el arco elegido.",
       "CST": "2,CP",
       "RNG": "S",
       "SUS": false,
@@ -12516,7 +12516,7 @@
     },
     {
       "name": "Stagger",
-      "text": "El modelo oponente objetivo recibe -1 DEF.",
+      "text": "El modelo enemigo objetivo recibe -1 DEF.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -12532,7 +12532,7 @@
     },
     {
       "name": "Disarm",
-      "text": "El modelo oponente objetivo recibe -2 TAC.",
+      "text": "El modelo enemigo objetivo recibe -2 TAC.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -12540,7 +12540,7 @@
     },
     {
       "name": "Weak Point",
-      "text": "El modelo oponente objetivo recibe -1 ARM.",
+      "text": "El modelo enemigo objetivo recibe -1 ARM.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -12548,7 +12548,7 @@
     },
     {
       "name": "One at a Time Lads!",
-      "text": "Los modelos aliados dentro de 2″ del modelo aliado objetivo ignoran la penalización de encierro",
+      "text": "Mientras estén dentro de 2″ del modelo aliado del gremio objetivo, los modelos aliados ignoran la penalización de encierro.",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -12556,7 +12556,7 @@
     },
     {
       "name": "Tooled Up",
-      "text": "El modelo aliado objetivo obtiene +1 DAÑO a las Character Plays que causan daño y a los resultados de daño de la Playbook.",
+      "text": "El modelo aliado del gremio objetivo obtiene +1 DAÑO a las Character Plays que causan daño y a los resultados de daño de la Playbook.",
       "CST": 1,
       "RNG": 4,
       "SUS": true,
@@ -12572,7 +12572,7 @@
     },
     {
       "name": "Use This!",
-      "text": "La Melee Zone del modelo aliado objetivo pasa a ser de 2″.",
+      "text": "La Melee Zone del modelo aliado del gremio objetivo pasa a ser de 2″.",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -12580,7 +12580,7 @@
     },
     {
       "name": "Dirty Knives",
-      "text": "El modelo oponente objetivo recibe -1 DEF, 1 DAÑO, y la condición de Poison.",
+      "text": "El modelo enemigo objetivo recibe -1 DEF, 1 DAÑO, y la condición de Poison.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": true,
@@ -12596,7 +12596,7 @@
     },
     {
       "name": "Shoemerang",
-      "text": "Otro modelo objetivo recibe 2 DAÑO. Elegí un modelo oponente dentro de 4″ del modelo objetive para que reciba la condición de Knocked Down.",
+      "text": "Otro modelo objetivo recibe 2 DAÑO. Elige un modelo enemigo dentro de 4″ del modelo objetivo para que reciba la condición de Knocked Down.",
       "CST": 2,
       "RNG": 4,
       "SUS": false,
@@ -12604,7 +12604,7 @@
     },
     {
       "name": "Shield Glare",
-      "text": "El modelo oponente objetivo recibe -1 TAC y -1 DEF.",
+      "text": "El modelo enemigo objetivo recibe -1 TAC y -1 DEF.",
       "CST": "CP",
       "RNG": 6,
       "SUS": true,
@@ -12612,7 +12612,7 @@
     },
     {
       "name": "Shield Throw",
-      "text": "Si el modelo oponente objetivo tiene la posesión de la pelota, pierde la posesión de la pelota. Después, realiza un desvío circular con la plantilla centrada en el modelo objetivo.",
+      "text": "Si el modelo enemigo objetivo tiene la posesión de la pelota, pierde la posesión de la pelota. Después, realiza un desvío circular con la plantilla centrada en el modelo objetivo.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": false,
@@ -12620,7 +12620,7 @@
     },
     {
       "name": "Howl",
-      "text": "Si el modelo oponente objetivo tiene la posesión de la pelota, pierde la posesión de la pelota. Después, realiza un desvío circular con la plantilla centrada en el modelo objetivo.",
+      "text": "Si el modelo enemigo objetivo tiene la posesión de la pelota, pierde la posesión de la pelota. Después, realiza un desvío circular con la plantilla centrada en el modelo objetivo.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": false,
@@ -12636,7 +12636,7 @@
     },
     {
       "name": "Impale",
-      "text": "El modelo oponente objetivo recibe 3 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe 3 DAÑO.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": false,
@@ -12644,7 +12644,7 @@
     },
     {
       "name": "Broadside",
-      "text": "El alcance de esta Character Playse mide desde el Culverin aliado. Posicióná dos AOE permanentes dentro del alcance. Los modelos impactados reciben 2 DAÑO. Esta AOE es terreno difícil.",
+      "text": "El alcance de esta Character Play se mide desde el Culverin aliado. Posiciona dos AOE permanentes dentro del alcance. Los modelos impactados reciben 2 DAÑO. Esta AOE es terreno difícil.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -12652,7 +12652,7 @@
     },
     {
       "name": "Chain Shot",
-      "text": "El alcance de esta Character Playse mide desde el Culverin aliado. El modelo oponente objetivo recibe 3 DAÑO y la condición de Knocked Down.",
+      "text": "El alcance de esta Character Play se mide desde el Culverin aliado. El modelo enemigo objetivo recibe 3 DAÑO y la condición de Knocked Down.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -12684,7 +12684,7 @@
     },
     {
       "name": "Commanding Aura",
-      "text": "Aura de 4″. Mientras que estén dentro de esta aura, los modelos aliados reciben +1 TAC y +1 DAÑO a los resultados de daño de la Playbook.",
+      "text": "Aura de 4″. Mientras que estén dentro de esta aura, los modelos aliados del gremio obtienen +1 TAC y +1 DAÑO a los resultados de daño de la Playbook.",
       "CST": "2,CP2",
       "RNG": "S",
       "SUS": true,
@@ -12692,7 +12692,7 @@
     },
     {
       "name": "Marked Target",
-      "text": "Cuando un modelo aliado hace una carga contra el modelo oponente objetivo, el modelo aliado obtiene +0″ /+2″ MOV mientras hace la carga.",
+      "text": "Cuando un modelo aliado hace una carga contra el modelo enemigo objetivo, el modelo aliado obtiene +0″ /+2″ MOV mientras hace la carga.",
       "CST": "1,CP",
       "RNG": 10,
       "SUS": true,
@@ -12724,7 +12724,7 @@
     },
     {
       "name": "Whisky Chaser",
-      "text": "La próxima vez que el modelo aliado realice un ataque con éxito, el modelo aliado puede agregar un {{KD}} adicional a los resultados de la Playbook.",
+      "text": "La próxima vez que el modelo aliado del gremio objetivo realice un ataque con éxito, el modelo aliado puede agregar un resultado de Playbook {{KD}} adicional.",
       "CST": 1,
       "RNG": 4,
       "SUS": true,
@@ -12732,7 +12732,7 @@
     },
     {
       "name": "Second Wind",
-      "text": "La proxima vez que el modelo aliado termina una activación, puede hacer un Dodge de 4″.",
+      "text": "La próxima vez que el modelo aliado del gremio objetivo termine una activación, puede hacer un Dodge de 4″.",
       "CST": 1,
       "RNG": 4,
       "SUS": true,
@@ -12740,7 +12740,7 @@
     },
     {
       "name": "Smashed Shins",
-      "text": "El modelo oponente objetivo recibe -4/-4″ KICK.",
+      "text": "El modelo enemigo objetivo recibe -4/-4″ KICK.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -12748,7 +12748,7 @@
     },
     {
       "name": "Howzat!?",
-      "text": "El modelo oponente objetivo recibe un Push de 4″ alejándose directamente de este modelo y la condición de Knocked Down.",
+      "text": "El modelo enemigo objetivo recibe un Push de 4″ alejándose directamente de este modelo y la condición de Knocked Down.",
       "CST": "CP",
       "RNG": "P",
       "SUS": false,
@@ -12756,7 +12756,7 @@
     },
     {
       "name": "Concussion",
-      "text": "Target enemy modelo loses 1 influencia.",
+      "text": "El modelo enemigo objetivo pierde 1 influencia.",
       "CST": "CP2",
       "RNG": "P",
       "SUS": false,
@@ -12772,7 +12772,7 @@
     },
     {
       "name": "Ball's Gone!",
-      "text": "El modelo oponente objetive pierde la posesión de la pelota y este modelo la gana, y este modelo puede luego hacer un pase sin gastar influencia.",
+      "text": "El modelo enemigo objetivo pierde la posesión de la pelota y este modelo la gana, y este modelo puede luego hacer un pase sin gastar influencia.",
       "CST": "CP2",
       "RNG": "P",
       "SUS": false,
@@ -12780,7 +12780,7 @@
     },
     {
       "name": "Goad",
-      "text": "Mientras que este modelo esté en la cancha, el modelo oponente objetivo sólo se puede mover directamente hacia este modelo mientras avanza.",
+      "text": "Mientras que este modelo esté en la cancha, el modelo enemigo objetivo sólo se puede mover directamente hacia este modelo mientras avanza.",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -12804,7 +12804,7 @@
     },
     {
       "name": "Flame Jet",
-      "text": "El modelo oponente objetivo recibe la condición de Burning y 3 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe la condición de Burning y 3 DAÑO.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -12820,7 +12820,7 @@
     },
     {
       "name": "They Ain't Tough!",
-      "text": "El modelo oponente objetivo recibe -1 ARM.",
+      "text": "El modelo enemigo objetivo recibe -1 ARM.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": true,
@@ -12828,7 +12828,7 @@
     },
     {
       "name": "Butchery",
-      "text": "Los modelos aliados obtienen +1 DAÑO a los resultados de daño de la Playbook cuando ataquen al modelo oponente objetivo.",
+      "text": "Los modelos aliados obtienen +1 DAÑO a los resultados de daño de la Playbook cuando ataquen al modelo enemigo objetivo.",
       "CST": "2,CP2",
       "RNG": 6,
       "SUS": true,
@@ -12836,7 +12836,7 @@
     },
     {
       "name": "Blood Rain",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO. Los modelos oponentes dentro de 3″ del modelo oponente objetivo reciben la condición de Bleed.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO. Los modelos enemigos dentro de 3″ del modelo enemigo objetivo reciben la condición de Bleed.",
       "CST": "CP2",
       "RNG": "P",
       "SUS": false,
@@ -12844,7 +12844,7 @@
     },
     {
       "name": "Pain Circle",
-      "text": "Posiciona una AOE duradera dentro del alcance.\nLos modelos impactados reciben 1 DAÑO y la condición de Bleed.\nLos modelos que entren terminen su activaciónd dentro de esta AOE reciben la condición de Bleed",
+      "text": "Posiciona una AOE duradera dentro del alcance.\nLos modelos impactados reciben 1 DAÑO y la condición de Bleed.\nLos modelos que entren o terminen su activación dentro de esta AOE reciben la condición de Bleed.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -12852,7 +12852,7 @@
     },
     {
       "name": "Rabid Animal",
-      "text": "El modelo oponente objetivo recibe -4″ /-4″ MOV y la condición de Poison.",
+      "text": "El modelo enemigo objetivo recibe -4″ /-4″ MOV y la condición de Poison.",
       "CST": "CP2",
       "RNG": "P",
       "SUS": true,
@@ -12860,7 +12860,7 @@
     },
     {
       "name": "Axe Throw",
-      "text": "El modelo oponente objetivo recibe 3 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe 3 DAÑO.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -12884,7 +12884,7 @@
     },
     {
       "name": "Route One",
-      "text": "Este modelo puede hacer un Jog directamente hacia el modelo oponente objetivo.",
+      "text": "Este modelo puede hacer un Jog directamente hacia el modelo enemigo objetivo.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": false,
@@ -12900,7 +12900,7 @@
     },
     {
       "name": "Whirling Chains",
-      "text": "Pulso de 4″. Los modelos oponentes dentro de este pulso reciben un Push de 4″ directamente hacia este modelo.",
+      "text": "Pulso de 4″. Los modelos enemigos dentro de este pulso reciben un Push de 4″ directamente hacia este modelo.",
       "CST": "2,CP2",
       "RNG": "S",
       "SUS": false,
@@ -12908,7 +12908,7 @@
     },
     {
       "name": "Thousand Cuts",
-      "text": "El modelo oponente objetivo recibe -2 DEF y 1 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe -2 DEF y 1 DAÑO.",
       "CST": "3,CP2",
       "RNG": 6,
       "SUS": true,
@@ -12916,7 +12916,7 @@
     },
     {
       "name": "Chef's Special",
-      "text": "Los modelos aliados que estén dentro de 4″ del modelo aliado objetivo obtienen +1 DAÑO a las Character Plays que causan daño y a los resultados de daño de la Playbook.",
+      "text": "Los modelos aliados del gremio que estén dentro de 4″ del modelo aliado objetivo obtienen +1 DAÑO a las Character Plays que causan daño y a los resultados de daño de la Playbook.",
       "CST": 1,
       "RNG": 4,
       "SUS": true,
@@ -12940,7 +12940,7 @@
     },
     {
       "name": "Turn Up the Heat",
-      "text": "Pulso de 3″ Los modelos oponentes dentro del pulso reciben la condición de Burning.",
+      "text": "Pulso de 3″. Los modelos enemigos dentro del pulso reciben la condición de Burning.",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": false,
@@ -12948,7 +12948,7 @@
     },
     {
       "name": "Intensify",
-      "text": "Pulso de 3″. Los modelos oponentes que tenga una condición dentro de este puso reciben 2 DAÑO..",
+      "text": "Pulso de 3″. Los modelos enemigos que tengan una condición dentro de este pulso reciben 2 DAÑO.",
       "CST": "2,CP",
       "RNG": "S",
       "SUS": false,
@@ -12964,7 +12964,7 @@
     },
     {
       "name": "Deadbolt",
-      "text": "El modelo oponente objetivo recibe un Push de 2″ alejándose directamente de este modelo, la condición de Knocked Down, y 3 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe un Push de 2″ alejándose directamente de este modelo, la condición de Knocked Down, y 3 DAÑO.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -12972,7 +12972,7 @@
     },
     {
       "name": "Minefield",
-      "text": "Aura de 4″. Los modelos oponentes que comiencen un avance dentro de esta aura, o que entren a esta aura como parte de un avance reciben 4 DAÑO. Esta aura se activa una sola vez por avance.",
+      "text": "Aura de 4″. Los modelos enemigos que comiencen un avance dentro de esta aura, o que entren a esta aura como parte de un avance reciben 4 DAÑO. Esta aura se activa una sola vez por avance.",
       "CST": "1,CP2",
       "RNG": "S",
       "SUS": true,
@@ -12980,7 +12980,7 @@
     },
     {
       "name": "Controller",
-      "text": "Cuando la activación de este modelo termina, el modelo aliado objetive puede, de ser posible, hacer inmediatamente su activación.",
+      "text": "Cuando la activación de este modelo termina, el modelo aliado del gremio objetivo puede, de ser posible, hacer inmediatamente su activación.",
       "CST": 2,
       "RNG": 6,
       "SUS": true,
@@ -12988,7 +12988,7 @@
     },
     {
       "name": "Alternator",
-      "text": "El modelo aliado objetivo obtiene +2″ /+2″ MOV.",
+      "text": "El modelo aliado del gremio objetivo obtiene +2″/+2″ MOV.",
       "CST": 2,
       "RNG": 6,
       "SUS": true,
@@ -12996,7 +12996,7 @@
     },
     {
       "name": "Deletion",
-      "text": "El modelo aliado objetivo obtiene +1 DAÑO a los resultados de daño de la Playbook.",
+      "text": "El modelo aliado del gremio objetivo obtiene +1 DAÑO a los resultados de daño de la Playbook.",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -13004,7 +13004,7 @@
     },
     {
       "name": "Elbow Grease",
-      "text": "Los resultados de daños de la Playbook del modelo aliado que no ean con momentum pasan a ser con momentum.",
+      "text": "Los resultados de daños de la Playbook del modelo aliado que no sean con momentum pasan a ser con momentum.",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -13012,7 +13012,7 @@
     },
     {
       "name": "Thief",
-      "text": "El modelo oponente objetive pierde la posesión de la pelota y este modelo la gana.",
+      "text": "El modelo enemigo objetivo pierde la posesión de la pelota y este modelo la gana.",
       "CST": "1,CP",
       "RNG": 1,
       "SUS": false,
@@ -13020,7 +13020,7 @@
     },
     {
       "name": "Burrow",
-      "text": "Coloca a este modelo en contacto peana con peana con el marcador de nido aliado objetivo.",
+      "text": "Coloca a este modelo en contacto base con base con el marcador de nido aliado objetivo.",
       "CST": 1,
       "RNG": 4,
       "SUS": false,
@@ -13028,7 +13028,7 @@
     },
     {
       "name": "Unexpected Arrival",
-      "text": "Pulso de 3″ Los modelos oponentes dentro de este pulso reciben un Push de 4″ alejándose directamente de este modelo.",
+      "text": "Pulso de 3″. Los modelos enemigos dentro de este pulso reciben un Push de 4″ alejándose directamente de este modelo.",
       "CST": "CP2",
       "RNG": "S",
       "SUS": false,
@@ -13036,7 +13036,7 @@
     },
     {
       "name": "Sucker Punch",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -13044,7 +13044,7 @@
     },
     {
       "name": "Destructive Impulse",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO y un Push de 2″.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO y un Push de 2″.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -13052,7 +13052,7 @@
     },
     {
       "name": "Remote Control",
-      "text": "Elije una pelota suelta. Este modelo puede puede hacer una Kick sin gastar influencia como si estuviera en posesión de la pelota. La distanca de la Kick y el Ball Path se miden desde la posición actual de la pelota suelta.",
+      "text": "Elige una pelota suelta. Este modelo puede hacer una Kick sin gastar influencia como si estuviera en posesión de la pelota. La distancia de la Kick y el Ball Path se miden desde la posición actual de la pelota suelta.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13060,7 +13060,7 @@
     },
     {
       "name": "Spark",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO y -1 ARM.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO y -1 ARM.",
       "CST": 2,
       "RNG": 6,
       "SUS": true,
@@ -13076,7 +13076,7 @@
     },
     {
       "name": "Arrow to the Knee",
-      "text": "El modelo oponente objetivo recibe -2/-2″ KICK y 2 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe -2/-2″ KICK y 2 DAÑO.",
       "CST": 2,
       "RNG": 8,
       "SUS": true,
@@ -13084,7 +13084,7 @@
     },
     {
       "name": "Floored Bolt",
-      "text": "El modelo oponente objetivo recibe la condición de Knocked Down y 2 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe la condición de Knocked Down y 2 DAÑO.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -13108,7 +13108,7 @@
     },
     {
       "name": "Air Mail",
-      "text": "este modelo puede hacer un pase sin gastar influencia. Este pase obtiene +0/+6″ KICK",
+      "text": "este modelo puede hacer un pase sin gastar influencia. Este pase obtiene +0/+6″ KICK.",
       "CST": 1,
       "RNG": "S",
       "SUS": false,
@@ -13116,7 +13116,7 @@
     },
     {
       "name": "Deadly Wings",
-      "text": "Elegí una AOE de Bandada. La AOE elegida puede ser posicionada dentro de 4″ de su posición actual.",
+      "text": "Elige una AOE de Harrier. La AOE elegida puede ser posicionada dentro de 4″ de su posición actual.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13132,7 +13132,7 @@
     },
     {
       "name": "Harrier",
-      "text": "Posiciona una AOE duradera dentro del alcance.\nLos modelos oponentes dentro de esta AOE reciben +1 DAÑO de Character Plays que causen daños y de resultados de daño de la Playbook.",
+      "text": "Posiciona una AOE duradera dentro del alcance.\nLos modelos enemigos dentro de esta AOE reciben +1 DAÑO de Character Plays que causen daños y de resultados de daño de la Playbook.",
       "CST": "2,CP",
       "RNG": 4,
       "SUS": false,
@@ -13148,7 +13148,7 @@
     },
     {
       "name": "Snap Fire",
-      "text": "El modelo oponente objetivo recibe 1 DAÑO.",
+      "text": "El modelo enemigo objetivo recibe 1 DAÑO.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13196,7 +13196,7 @@
     },
     {
       "name": "Cocksure",
-      "text": "El modelo aliado objetivo puede ignorar la próxima condiciona que recibe excepto la condición de Knocked Out.",
+      "text": "El modelo aliado objetivo puede ignorar la próxima condición que recibe excepto la condición de Taken Out.",
       "CST": 1,
       "RNG": 4,
       "SUS": true,
@@ -13236,7 +13236,7 @@
     },
     {
       "name": "Crop Dusting",
-      "text": "Posiciona una AOE dentro del alcance. Los modelos impactados reciben 2 DAÑO. Este modelo puede posicionar hasta dos marcadres de cosecha aliados dentro de la AdE.",
+      "text": "Posiciona una AOE dentro del alcance. Los modelos impactados reciben 2 DAÑO. Este modelo puede posicionar hasta dos marcadores de cosecha aliados dentro de la AOE.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13252,7 +13252,7 @@
     },
     {
       "name": "Mow Down",
-      "text": "El modelo oponente objetivo recibe la condición de Knocked Down. Los otros modelos dentro de la Melee Zone de este modelo reciben la condición de Knocked Down.",
+      "text": "El modelo enemigo objetivo recibe la condición de Knocked Down. Los otros modelos dentro de la Melee Zone de este modelo reciben la condición de Knocked Down.",
       "CST": "CP",
       "RNG": "P",
       "SUS": false,
@@ -13276,7 +13276,7 @@
     },
     {
       "name": "Drag",
-      "text": "El modelo oponente objetivo recibe un empujun de 6″ directamente hacia este modelo.",
+      "text": "El modelo enemigo objetivo recibe un Push de 6″ directamente hacia este modelo.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": false,
@@ -13284,7 +13284,7 @@
     },
     {
       "name": "Rough Seas",
-      "text": "El modelo oponente objetive pierde la posesión de la pelota y este modelo la gana.",
+      "text": "El modelo enemigo objetivo pierde la posesión de la pelota y este modelo la gana.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -13300,7 +13300,7 @@
     },
     {
       "name": "Break the Surface",
-      "text": "Elegí un modelo oponente o una pelota libre dentro del alcance. Posiciona el modelo o la pelita libre dentro de 4″ de su posición actual.",
+      "text": "Elige un modelo enemigo o una pelota libre dentro del alcance. Posiciona el modelo o la pelota libre dentro de 4″ de su posición actual.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -13316,7 +13316,7 @@
     },
     {
       "name": "Heavy Tackle",
-      "text": "El modelo oponente objetive pierde la posesión de la pelota y este modelo la gana y el modelo oponente recibe la condición de Knocked Down.",
+      "text": "El modelo enemigo objetivo pierde la posesión de la pelota y este modelo la gana y el modelo enemigo recibe la condición de Knocked Down.",
       "CST": "CP",
       "RNG": "P",
       "SUS": false,
@@ -13324,7 +13324,7 @@
     },
     {
       "name": "Fancy Footwork",
-      "text": "El modelo oponente objetive pierde la posesión de la pelota y este modelo la gana.",
+      "text": "El modelo enemigo objetivo pierde la posesión de la pelota y este modelo la gana.",
       "CST": "CP",
       "RNG": 4,
       "SUS": false,
@@ -13332,7 +13332,7 @@
     },
     {
       "name": "Raise the Black Flag",
-      "text": "El modelo oponente objetivo recibe -2″ /-2″ MOV. Elegí un modelo aliado dentro de 6″. El modelo aliado elegido obtiene +2″ /+2″ MOV.",
+      "text": "El modelo enemigo objetivo recibe -2″ /-2″ MOV. Elige un modelo aliado dentro de 6″. El modelo aliado elegido obtiene +2″ /+2″ MOV.",
       "CST": "CP",
       "RNG": 6,
       "SUS": true,
@@ -13340,7 +13340,7 @@
     },
     {
       "name": "Lure",
-      "text": "El modelo oponente objetivo hace una Jog directamente hacia este modelo. El modelo objetivo se considera aliado durante esta acción.",
+      "text": "El modelo enemigo objetivo hace una Jog directamente hacia este modelo. El modelo objetivo se considera aliado durante esta acción.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -13348,7 +13348,7 @@
     },
     {
       "name": "Seduced",
-      "text": "El modelo oponente objetivo hace un pase o un ataque sin gastar influencia. El modelo objetivo se considera aliado durante esta acción.",
+      "text": "El modelo enemigo objetivo hace un pase o un ataque sin gastar influencia. El modelo objetivo se considera aliado durante esta acción.",
       "CST": "3,CP2",
       "RNG": 4,
       "SUS": false,
@@ -13356,7 +13356,7 @@
     },
     {
       "name": "Dread Gaze",
-      "text": "El modelo oponente objetivo recibe un Push de 2″ alejándose directamente de este modelo y la condición de Knocked Down.",
+      "text": "El modelo enemigo objetivo recibe un Push de 2″ alejándose directamente de este modelo y la condición de Knocked Down.",
       "CST": 2,
       "RNG": 6,
       "SUS": false,
@@ -13364,7 +13364,7 @@
     },
     {
       "name": "Fair Wind",
-      "text": "La pelota libre objetive es posicionada dentro de 4″ de su posición actual.",
+      "text": "La pelota libre objetivo es posicionada dentro de 4″ de su posición actual.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13372,7 +13372,7 @@
     },
     {
       "name": "Pinned",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO. Mientras que este modelo esté en la cancha, el modelo oponente objetivo sólo se puede mover directamente hacia este modelo mientras avanza.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO. Mientras que este modelo esté en la cancha, el modelo enemigo objetivo sólo se puede mover directamente hacia este modelo mientras avanza.",
       "CST": 2,
       "RNG": 8,
       "SUS": true,
@@ -13380,7 +13380,7 @@
     },
     {
       "name": "Sun Strike",
-      "text": "Cuando el modelo aliado objetivo impacta a un o más modelos oponentes con Character Play, luego de resolver la Character Play, el equipo aliado obtiene 1 MP.",
+      "text": "Cuando el modelo aliado objetivo impacta a un o más modelos enemigos con Character Play, luego de resolver la Character Play, el equipo aliado obtiene 1 MP.",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -13388,7 +13388,7 @@
     },
     {
       "name": "Blessing of the Moon Goddess",
-      "text": "La próxima vez que el modelo aliado objetive hace un ataque con éxito, el modelo aliado puede agregar un {{dd}} adicional a los resultados de la Playbook",
+      "text": "La próxima vez que el modelo aliado objetivo hace un ataque con éxito, el modelo aliado puede agregar un {{dd}} adicional a los resultados de la Playbook.",
       "CST": 1,
       "RNG": 4,
       "SUS": true,
@@ -13396,7 +13396,7 @@
     },
     {
       "name": "Cold Snap",
-      "text": "Posiciona una AOE dentro del alcance. Los modelos impactados reciben 2 DAÑO y la condición de atrapado.",
+      "text": "Posiciona una AOE dentro del alcance. Los modelos impactados reciben 2 DAÑO y la condición de Snared.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": false,
@@ -13412,7 +13412,7 @@
     },
     {
       "name": "Bait",
-      "text": "Posiciona una AOE dentro del alcance. Este modelo puede posicionar dos marcadore sde trampa dentro del AdE.. Los modelos oponentes impactados reciben un Push de 1″.",
+      "text": "Posiciona una AOE dentro del alcance. Este modelo puede posicionar dos marcadores de trampa dentro de la AOE. Los modelos enemigos impactados reciben un Push de 1″.",
       "CST": "2,CP",
       "RNG": 3,
       "SUS": false,
@@ -13432,11 +13432,11 @@
       "RNG": 2,
       "SUS": false,
       "OPT": true,
-      "text": "Posiciona un AOE dentro del alcance. Los otros modelos impactados reciben  4 DMG y un Push 4″ alejándose directamente de este modelo."
+      "text": "Posiciona una AOE dentro del alcance. Los otros modelos impactados reciben 4 DAÑO y un Push de 4″ alejándose directamente de este modelo."
     },
     {
       "name": "Entangle",
-      "text": "El modelo oponente objetivo recibe la condición de atrapado.",
+      "text": "El modelo enemigo objetivo recibe la condición de Snared.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": false,
@@ -13444,7 +13444,7 @@
     },
     {
       "name": "Flurry",
-      "text": "Los modelos dentro de 2″ del modelo oponente objetivo reciben 2 DAÑO.",
+      "text": "Los modelos dentro de 2″ del modelo enemigo objetivo reciben 2 DAÑO.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -13452,7 +13452,7 @@
     },
     {
       "name": "Skewered",
-      "text": "El modelo oponente objetivo recibe 3 DAÑO y la condición de atrapado.",
+      "text": "El modelo enemigo objetivo recibe 3 DAÑO y la condición de Snared.",
       "CST": "2,CP2",
       "RNG": 6,
       "SUS": false,
@@ -13460,7 +13460,7 @@
     },
     {
       "name": "Gut & String",
-      "text": "El modelo oponente objetivo recibe -2″ /-2″ MOV y -1 DEF.",
+      "text": "El modelo enemigo objetivo recibe -2″ /-2″ MOV y -1 DEF.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -13468,7 +13468,7 @@
     },
     {
       "name": "Marked for Death",
-      "text": "A friendly modelo that declares a charge aobtienet an enemy modelo that’s within this model’s melee zone spends 1 less influencia y obtiene +0″ /+2″ MOV for the duration of the charge.",
+      "text": "Un modelo aliado que declare una carga contra un modelo enemigo que esté dentro de la Melee Zone de este modelo gasta 1 influencia menos y obtiene +0″/+2″ MOV mientras dure la carga.",
       "CST": "2,CP",
       "RNG": "S",
       "SUS": true,
@@ -13492,7 +13492,7 @@
     },
     {
       "name": "Chain Bolas",
-      "text": "El modelo oponente objetivo recibe la condición de atrapado y la condición de Knocked Down.",
+      "text": "El modelo enemigo objetivo recibe la condición de Snared y la condición de Knocked Down.",
       "CST": "2,CP",
       "RNG": 6,
       "SUS": false,
@@ -13508,7 +13508,7 @@
     },
     {
       "name": "Dummy Pass",
-      "text": "Otro modelo aliado objetivo puede hacer un Dodge de 4″.",
+      "text": "Otro modelo aliado del gremio objetivo puede hacer un Dodge de 4″.",
       "CST": 1,
       "RNG": 8,
       "SUS": false,
@@ -13516,7 +13516,7 @@
     },
     {
       "name": "Towering Presence",
-      "text": "Aura de 4″. Los otros modelos aliados dentro de esta aura puede gastar 1 MP menos para usar Pase en Movimiento o hacer un Remate de Primera.",
+      "text": "Aura de 4″. Los otros modelos aliados del gremio dentro de esta aura pueden gastar 1 MP menos para usar Pass & Move o hacer un Snap Shot.",
       "CST": 1,
       "RNG": "S",
       "SUS": true,
@@ -13524,7 +13524,7 @@
     },
     {
       "name": "Fulcrum",
-      "text": "Aura de 6\n. Los modelos aliados dentro de esta aura obtien Poised.\n{{trait 'Poised'}}",
+      "text": "Aura de 6″. Los modelos aliados dentro de esta aura obtienen Poised.\n{{trait 'Poised'}}",
       "CST": 1,
       "RNG": "S",
       "SUS": true,
@@ -13540,7 +13540,7 @@
     },
     {
       "name": "Squad Tactics",
-      "text": "Otro modelo aliado objetivo obtiene Asssist [Chisel].\n{{trait 'Asssist' 'Chisel'}}",
+      "text": "Otro modelo aliado del gremio objetivo obtiene Assist [Chisel].\n{{trait 'Assist' 'Chisel'}}",
       "CST": 1,
       "RNG": 6,
       "SUS": true,
@@ -13548,7 +13548,7 @@
     },
     {
       "name": "Lodestone",
-      "text": "Elegí una opción:\n- Otros modelos dentro de 4″ de del modelo oponente objetivo reciben un Push de 2″ directamente hacia el modelo oponente objetivo.\n- Otros modelos dentro de 4″ de del modelo oponente objetivo reciben un Push de 2″ alejándose directamente del modelo oponente objetivo.",
+      "text": "Elige una opción:\n- Otros modelos dentro de 4″ del modelo enemigo objetivo reciben un Push de 2″ directamente hacia el modelo enemigo objetivo.\n- Otros modelos dentro de 4″ del modelo enemigo objetivo reciben un Push de 2″ alejándose directamente del modelo enemigo objetivo.",
       "CST": "2,CP2",
       "RNG": 8,
       "SUS": false,
@@ -13564,7 +13564,7 @@
     },
     {
       "name": "Grinding Tracks",
-      "text": "Cuando este modelo avanza, los modelos oponentes cuya peana quede en contacto peana con peana con la peana de este modelo reciben la condición de Knocked Down. Cada modelo sólo recibe la condición de Knocked Down una vez por turno por efecto de Orugas aplastantes.",
+      "text": "Cuando este modelo avanza, los modelos enemigos cuya peana quede en contacto base con base con la peana de este modelo reciben la condición de Knocked Down. Cada modelo sólo recibe la condición de Knocked Down una vez por turno por efecto de Grinding Tracks.",
       "CST": 1,
       "RNG": "S",
       "SUS": true,
@@ -13572,7 +13572,7 @@
     },
     {
       "name": "Sinkhole",
-      "text": "Pulso de 3″ Los modelos oponentes dentro de este pulso reciben un Push de 3″ directamente hacia este modelo. Este modelo puede luego ser posicionado dentro 2″ de su posición actual.",
+      "text": "Pulso de 3″. Los modelos enemigos dentro de este pulso reciben un Push de 3″ directamente hacia este modelo. Este modelo puede luego ser posicionado dentro de 2″ de su posición actual.",
       "CST": "2,CP",
       "RNG": "S",
       "SUS": false,
@@ -13580,7 +13580,7 @@
     },
     {
       "name": "Clear!",
-      "text": "Posiciona una AOE dentro del alcance. Los modelos oponentes impactados son posicionados dentro de 1″ de su posición actual.",
+      "text": "Posiciona una AOE dentro del alcance. Los modelos enemigos impactados son posicionados dentro de 1″ de su posición actual.",
       "CST": 2,
       "RNG": 4,
       "SUS": false,
@@ -13588,7 +13588,7 @@
     },
     {
       "name": "Under the Lines",
-      "text": "Elegí un modelo oponente dentro de 3″. Posiciona este modelo en contacto base con base con el modelo oponente objetivo.",
+      "text": "Elige un modelo enemigo dentro de 3″. Posiciona este modelo en contacto base con base con el modelo enemigo objetivo.",
       "CST": 1,
       "RNG": "S",
       "SUS": false,
@@ -13596,7 +13596,7 @@
     },
     {
       "name": "Lockdown",
-      "text": "El modelo oponente objetivo recibe -4″ /-4″ MOV.",
+      "text": "El modelo enemigo objetivo recibe -4″ /-4″ MOV.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -13604,7 +13604,7 @@
     },
     {
       "name": "Throw",
-      "text": "El modelo oponente objetivo pude ser posicionado dentro de 1″ de su posición actual.",
+      "text": "El modelo enemigo objetivo puede ser posicionado dentro de 1″ de su posición actual.",
       "CST": "CP",
       "RNG": "P",
       "SUS": false,
@@ -13612,7 +13612,7 @@
     },
     {
       "name": "Misdirection",
-      "text": "El modelo oponente objetivo con al menos 1 influencia pierde 1 influencia. aloca una 1 influencia a otro modelo aliado dentro de 4″ de este modelo.",
+      "text": "El modelo enemigo objetivo con al menos 1 influencia pierde 1 influencia. Aloca 1 influencia a otro modelo aliado del gremio dentro de 4″ de este modelo.",
       "CST": 2,
       "RNG": 8,
       "SUS": false,
@@ -13620,7 +13620,7 @@
     },
     {
       "name": "Puppet Master",
-      "text": "Aloca 1 influencia a este modelo. El modelo objetivo puede hacer un trote, hacer un pase, o hacer un ataque sin gastar influencia. El modelo objetivo se considera aliado durante esta acción.",
+      "text": "Aloca 1 influencia a este modelo. El modelo objetivo puede hacer un Jog, hacer un pase, o hacer un ataque sin gastar influencia. El modelo objetivo se considera aliado durante esta acción.",
       "CST": 4,
       "RNG": 8,
       "SUS": false,
@@ -13628,7 +13628,7 @@
     },
     {
       "name": "Spirit Bomb",
-      "text": "Posiciona una AOE dentro del alcance. Los modelos oponentes impactados reciben 2 DAÑO y un Push de 2″.",
+      "text": "Posiciona una AOE dentro del alcance. Los modelos enemigos impactados reciben 2 DAÑO y un Push de 2″.",
       "CST": "2,CP",
       "RNG": 4,
       "SUS": false,
@@ -13660,7 +13660,7 @@
     },
     {
       "name": "Spirit Strings",
-      "text": "El modelo oponente objetivo recibe un Push de 2″. Este modelo puede luego hacer un Dodge de2″ hacia el modelo oponente objetivo. Cada modelo puede ser objetivo de Hilos espirituales solo una vez por turno.",
+      "text": "El modelo enemigo objetivo recibe un Push de 2″. Este modelo puede luego hacer un Dodge de 2″ hacia el modelo enemigo objetivo. Cada modelo puede ser objetivo de Spirit Strings solo una vez por turno.",
       "CST": "CP",
       "RNG": 4,
       "SUS": false,
@@ -13668,7 +13668,7 @@
     },
     {
       "name": "Puppet Show [Memory]",
-      "text": "El modelo aliado mencionado objetivo puede hacer un ataque sin gastar influencia or hacer un Dodge de 2″.",
+      "text": "El modelo aliado mencionado objetivo puede hacer un ataque sin gastar influencia o hacer un Dodge de 2″.",
       "CST": 1,
       "RNG": 8,
       "SUS": false,
@@ -13676,7 +13676,7 @@
     },
     {
       "name": "Pulling the Strings [Memory]",
-      "text": "El modelo aliado mencionado objetivo puede may puede hacer una Kick sin gastar influencia.",
+      "text": "El modelo aliado mencionado objetivo puede hacer una Kick sin gastar influencia.",
       "CST": 1,
       "RNG": 8,
       "SUS": false,
@@ -13684,7 +13684,7 @@
     },
     {
       "name": "Ghostly Visage",
-      "text": "Posiciona una AOE duradera dentro del alcance.\n Cuando un modelo oponente declara una carga a un modelo aliado dentro de esta AdE, el modelo oponento recibe -0″ /-4″ MOV y -2 TAC mientras dura la carga.",
+      "text": "Posiciona una AOE duradera dentro del alcance.\nCuando un modelo enemigo declara una carga a un modelo aliado dentro de esta AOE, el modelo enemigo recibe -0″/-4″ MOV y -2 TAC mientras dura la carga.",
       "CST": 1,
       "RNG": 2,
       "SUS": true,
@@ -13692,7 +13692,7 @@
     },
     {
       "name": "Heavy Burden",
-      "text": "El modelo oponente objetivo recibe -4″ /-4″ MOV y -2 a dados a la tirada cuando haga una Character Plays.",
+      "text": "El modelo enemigo objetivo recibe -4″ /-4″ MOV y -2 a dados a la tirada cuando haga Character Plays.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": true,
@@ -13700,7 +13700,7 @@
     },
     {
       "name": "Carrion Call",
-      "text": "Target friendly Dirge may declare an attack or charge without spending influence.",
+      "text": "El Dirge aliado objetivo puede hacer un ataque o cargar sin gastar influencia.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13724,7 +13724,7 @@
     },
     {
       "name": "Exhaustion",
-      "text": "Aura de 4″. Los modelos oponentes dentro de esta auras tienen que gastar +1 MP para hacer un contrataque.",
+      "text": "Aura de 4″. Los modelos enemigos dentro de esta aura tienen que gastar +1 MP para hacer un contraataque.",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": true,
@@ -13732,7 +13732,7 @@
     },
     {
       "name": "Smelling Salts",
-      "text": "Posiciona una AOE dentro del alcance. Friendly models within this AOE remove any conditions they're currently suffering.",
+      "text": "Posiciona una AOE dentro del alcance. Los modelos aliados dentro de esta AOE se quitan cualquier condición que tengan.",
       "CST": 2,
       "RNG": 2,
       "SUS": false,
@@ -13740,7 +13740,7 @@
     },
     {
       "name": "Shutout",
-      "text": "Si el modelo oponente objetivo no ha activado todavía este turno, debe ser el último modelo del equipo oponente en activar.",
+      "text": "Si el modelo enemigo objetivo no ha activado todavía este turno, debe ser el último modelo del equipo enemigo en activar.",
       "CST": 1,
       "RNG": 8,
       "SUS": true,
@@ -13748,7 +13748,7 @@
     },
     {
       "name": "Tucked",
-      "text": "Si el modelo oponente objetivo no ha activado todavía este turno, debe ser el siguiente modelo del equipo oponente en activar.",
+      "text": "Si el modelo enemigo objetivo no ha activado todavía este turno, debe ser el siguiente modelo del equipo enemigo en activar.",
       "CST": 1,
       "RNG": 8,
       "SUS": true,
@@ -13772,7 +13772,7 @@
     },
     {
       "name": "Netted",
-      "text": "El modelo oponente objetivo recibe la condición de Knocked Down.",
+      "text": "El modelo enemigo objetivo recibe la condición de Knocked Down.",
       "CST": "2,CP",
       "RNG": 4,
       "SUS": false,
@@ -13780,7 +13780,7 @@
     },
     {
       "name": "Grasping Earth",
-      "text": "El modelo oponente objetivo recibe -2″ /-2″ MOV.",
+      "text": "El modelo enemigo objetivo recibe -2″ /-2″ MOV.",
       "CST": "1,CP",
       "RNG": 6,
       "SUS": true,
@@ -13796,7 +13796,7 @@
     },
     {
       "name": "With Aplomb",
-      "text": "La próxima vez que este modelo haga un gol, el equipo aliado gana +1 PV.",
+      "text": "La próxima vez que este modelo haga un gol, el equipo aliado gana +1 VP.",
       "CST": "CP",
       "RNG": "S",
       "SUS": true,
@@ -13804,7 +13804,7 @@
     },
     {
       "name": "Predatory Gaze",
-      "text": "Mientras que este modelo este dentro de 10″ del arco aliado, los modelos oponentes deben gastar una influencia adicional para hacer un remate.",
+      "text": "Mientras que este modelo esté dentro de 10″ del arco aliado, los modelos enemigos deben gastar una influencia adicional para hacer un Shot.",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": true,
@@ -13836,7 +13836,7 @@
     },
     {
       "name": "Pay the Piper",
-      "text": "Aura de 6\n. Cuando un modelo oponente dentro de esta aura gasta MP, el equipo aliado gana 1 MP.",
+      "text": "Aura de 6″. Cuando un modelo enemigo dentro de esta aura gasta MP, el equipo aliado gana 1 MP.",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": true,
@@ -13844,7 +13844,7 @@
     },
     {
       "name": "Reverie",
-      "text": "Otro modelo objetivo aliado puede hacer un Sprint o hacer un remate sin gastar influencia.",
+      "text": "Otro modelo objetivo aliado puede hacer un Sprint y hacer un Shot sin gastar influencia.",
       "CST": 3,
       "RNG": 8,
       "SUS": false,
@@ -13852,7 +13852,7 @@
     },
     {
       "name": "Dreadful Shriek",
-      "text": "El modelo oponente objetivo hace un trote. El modelo objetivo se considera aliado durante esta acción.",
+      "text": "El modelo enemigo objetivo hace un Jog. El modelo objetivo se considera aliado durante esta acción.",
       "CST": "1,CP",
       "RNG": 2,
       "SUS": false,
@@ -13860,7 +13860,7 @@
     },
     {
       "name": "Erupting Sores",
-      "text": "Pulso 2″. El jugador oponente ekije uno de los siguientes:\n- Los modelos oponentes dentro de este pulso reciben 2 DAÑO y la condición de Poison.\n- Los modelos oponentes dentro de este pulso reciben 2 DAÑO y la condición de Bleed.",
+      "text": "Pulso de 2″. El jugador enemigo elige uno de los siguientes:\n- Los modelos enemigos dentro de este pulso reciben 2 DAÑO y la condición de Poison.\n- Los modelos enemigos dentro de este pulso reciben 2 DAÑO y la condición de Bleed.",
       "CST": "2,CP",
       "RNG": "S",
       "SUS": false,
@@ -13892,7 +13892,7 @@
     },
     {
       "name": "Baa Ram Ewe",
-      "text": "El modelo oponente objetivo recibe un Push de 2″.",
+      "text": "El modelo enemigo objetivo recibe un Push de 2″.",
       "CST": 1,
       "RNG": 6,
       "SUS": false,
@@ -13940,7 +13940,7 @@
     },
     {
       "name": "Forward, Minions!",
-      "text": "Aura de 6\n. Los modelos aliados que empiecen un avance dentro de esta aura obtienen +2″ /+2″ MOV mientras dure el avance.",
+      "text": "Aura de 6″. Los modelos aliados que empiecen un avance dentro de esta aura obtienen +2″/+2″ MOV mientras dure el avance.",
       "CST": 3,
       "RNG": "S",
       "SUS": true,
@@ -13956,7 +13956,7 @@
     },
     {
       "name": "Constrict",
-      "text": "El modelo oponente objetivo recibe -4″ /-4″ MOV.",
+      "text": "El modelo enemigo objetivo recibe -4″ /-4″ MOV.",
       "CST": "CP",
       "RNG": "P",
       "SUS": true,
@@ -13964,7 +13964,7 @@
     },
     {
       "name": "Chain Grab",
-      "text": "El modelo oponente objetivo recibe un Push de 6″ directamente hacia este modelo.",
+      "text": "El modelo enemigo objetivo recibe un Push de 6″ directamente hacia este modelo.",
       "CST": "CP2",
       "RNG": 6,
       "SUS": false,
@@ -13972,7 +13972,7 @@
     },
     {
       "name": "Lens Flare",
-      "text": "Cuando el modelo oponente objetivo vaya a hacer una tirada de dados para un ataque o una Kick, los modificadores que apliquen y el dado extra de Tiempo Extra no pueden causar que la tirada contenga más dados que el TAC o el KICK impreso en la carta del modelo.",
+      "text": "Cuando el modelo enemigo objetivo vaya a hacer una tirada de dados para un ataque o una Kick, los modificadores que apliquen y el dado extra de Tiempo Extra no pueden causar que la tirada contenga más dados que el TAC o el KICK impreso en la carta del modelo.",
       "CST": "CP",
       "RNG": 4,
       "SUS": true,
@@ -13988,7 +13988,7 @@
     },
     {
       "name": "Burn Baby Burn",
-      "text": "Este modelo y el modelo oponente objetivo ambos reciben la condición de Burning.",
+      "text": "Este modelo y el modelo enemigo objetivo ambos reciben la condición de Burning.",
       "CST": "CP",
       "RNG": "P",
       "SUS": false,
@@ -13996,7 +13996,7 @@
     },
     {
       "name": "Alchemical Bomb",
-      "text": "Posiciona una AOE dentro del alcance.\nLos modelos impactados reciben 1 DAÑO de condición y la condición de Poison y la condición de Poisons.",
+      "text": "Posiciona una AOE dentro del alcance.\nLos modelos impactados reciben 1 DAÑO de condición y las condiciones de Burning y Poison.",
       "CST": "CP",
       "RNG": 2,
       "SUS": false,
@@ -14020,7 +14020,7 @@
     },
     {
       "name": "Pig Stickin'",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO y un Push de 4″ directamente hacia este modelo.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO y un Push de 4″ directamente hacia este modelo.",
       "CST": "CP",
       "RNG": 6,
       "SUS": false,
@@ -14028,7 +14028,7 @@
     },
     {
       "name": "Careless Whisper",
-      "text": "Coloca un marcador de susurro en el modelo oponente objetivo.\nFLos modelos aliados que no sean Capitán obtienen +2 TAC cuando ataquen a un modelo con un marcador de suspiro.\n Los marcadores de suspiro sólo se remueven del modelo objetivo cuando recibe la condición de Knocked Out.",
+      "text": "Coloca un marcador de susurro en el modelo enemigo objetivo.\nLos modelos aliados que no sean Capitán obtienen +2 TAC cuando ataquen a un modelo con un marcador de susurro.\nLos marcadores de susurro sólo se remueven del modelo objetivo cuando recibe la condición de Taken Out.",
       "CST": "2,CP",
       "RNG": 7,
       "SUS": false,
@@ -14036,7 +14036,7 @@
     },
     {
       "name": "Transmute",
-      "text": "El modelo aliado objetivo puede quitarse cualquier cantidad de condiciones que tenga, y luego recibe\nla condición de Poison.",
+      "text": "El modelo aliado objetivo puede quitarse cualquier cantidad de condiciones que tenga, y luego recibe la condición de Poison.",
       "CST": 1,
       "RNG": 4,
       "SUS": false,
@@ -14044,7 +14044,7 @@
     },
     {
       "name": "Bladework",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO. Este modelo puede luego hacer un Dodge de 2″ directamente hacia el modelo oponente objetivo. Cada modelo oponente sólo puede ser objetivo de Finta de esgrima una vez por turno.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO. Este modelo puede luego hacer un Dodge de 2″ directamente hacia el modelo enemigo objetivo. Cada modelo enemigo sólo puede ser objetivo de Bladework una vez por turno.",
       "CST": "CP",
       "RNG": 4,
       "SUS": false,
@@ -14052,7 +14052,7 @@
     },
     {
       "name": "Jagged Blade",
-      "text": "El modelo oponente objetivo recibe 2 DAÑO y la condición de Bleed.",
+      "text": "El modelo enemigo objetivo recibe 2 DAÑO y la condición de Bleed.",
       "CST": "2,CP",
       "RNG": 4,
       "SUS": false,
@@ -14060,7 +14060,7 @@
     },
     {
       "name": "Pick of the Crop",
-      "text": "Cuando un modelo aliado hace una carga contra el modelo oponente objetivo, el modelo aliado  obtiene +0″ /+2″ MOV y puede mover por sobre marcadores de cosecha sin quitarlos de la cancha.",
+      "text": "Cuando un modelo aliado hace una carga contra el modelo enemigo objetivo, el modelo aliado obtiene +0″ /+2″ MOV y puede mover por sobre marcadores de cosecha sin quitarlos de la cancha.",
       "CST": "1,CP",
       "RNG": 10,
       "SUS": true,
@@ -14124,7 +14124,7 @@
     },
     {
       "name": "Aqua Tofana",
-      "text": "Aura de 4″. Los modelos oponentes dentro de esta aura que tengan la condición de Poison reciben -1 TAC y reciben 3 DAÑO de veneno en la fase final en vez de 2 DAÑO.",
+      "text": "Aura de 4″. Los modelos enemigos dentro de esta aura que tengan la condición de Poison reciben -1 TAC y reciben 3 DAÑO de Poison en la Fase Final en vez de 2 DAÑO.",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": true,
@@ -14140,7 +14140,7 @@
     },
     {
       "name": "Cut Em Down",
-      "text": "Los modelos oponentes que estén dentro de la Melee Zone de este modelo reciben -1 DEF y -2″ /-2″ MOV.",
+      "text": "Los modelos enemigos que estén dentro de la Melee Zone de este modelo reciben -1 DEF y -2″ /-2″ MOV.",
       "CST": "CP",
       "RNG": "S",
       "SUS": true,
@@ -14156,7 +14156,7 @@
     },
     {
       "name": "Axe A Question",
-      "text": "Este modelo obtiene Asssist [Mallet, Oak].\n{{trait 'Asssist' 'Mallet, Oak'}}",
+      "text": "Este modelo obtiene Assist [Mallet, Oak].\n{{trait 'Assist' 'Mallet, Oak'}}",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": true,
@@ -14164,7 +14164,7 @@
     },
     {
       "name": "Marked for Felling",
-      "text": "Cuando un modelo aliado hace una carga contra el modelo oponente objetivo, el modelo aliado obtiene +0/+2″ MOV y el modelo puede mover por sobre obstrucciones por la duración de la carga. El modelo aliado no puede terminar su movimiento sobre una obstrucción.",
+      "text": "Cuando un modelo aliado hace una carga contra el modelo enemigo objetivo, el modelo aliado obtiene +0/+2″ MOV y el modelo puede mover por sobre obstrucciones por la duración de la carga. El modelo aliado no puede terminar su movimiento sobre una obstrucción.",
       "CST": "1,CP",
       "RNG": 10,
       "SUS": true,
@@ -14172,7 +14172,7 @@
     },
     {
       "name": "Reconnaissance",
-      "text": "Aura de 6\n. Los modelos aliados dentro de esta aura no reciben la penalización de -1 TAC por atacar un modelo en cobertura.",
+      "text": "Aura de 6″. Los modelos aliados dentro de esta aura no reciben la penalización de -1 TAC por atacar un modelo en cobertura.",
       "CST": 1,
       "RNG": "S",
       "SUS": true,
@@ -14180,7 +14180,7 @@
     },
     {
       "name": "Swipe Right",
-      "text": "El modelo oponente objetivo recibe un Push de 2″. Luego podés elegir un Log Pile en el alcance y posicionarlo dentro de 1″ de este modelo.",
+      "text": "El modelo enemigo objetivo recibe un Push de 2″. Luego puedes elegir un Log Pile en el alcance y posicionarlo dentro de 1″ de este modelo.",
       "CST": "CP",
       "RNG": 4,
       "SUS": false,
@@ -14196,7 +14196,7 @@
     },
     {
       "name": "Dam Builder",
-      "text": "Elegí un Log Pile dentro del alcance y posiciónalo dentro de 4″ de su posición actual.",
+      "text": "Elige un Log Pile dentro del alcance y posiciónalo dentro de 4″ de su posición actual.",
       "CST": "1,CP",
       "RNG": 1,
       "SUS": false,
@@ -14212,7 +14212,7 @@
     },
     {
       "name": "Steel Toecaps",
-      "text": "El modelo objetivo aliado obtiene +1 ARM y +0/+2″ KICK",
+      "text": "El modelo objetivo aliado obtiene +1 ARM y +0/+2″ KICK.",
       "CST": 2,
       "RNG": 4,
       "SUS": true,
@@ -14220,7 +14220,7 @@
     },
     {
       "name": "The Bigger They Are...",
-      "text": "El modelo oponente objetivo recibe daño de condición igual a la mitad de su salud actual, redondeando hacia abajo. Luego, si hay hay un Log Pile aliado dentro de 4″ de este modelo, puedes posicionar este modelo en contacto base con base con ese Log Pile.",
+      "text": "El modelo enemigo objetivo recibe daño de condición igual a la mitad de su salud actual, redondeando hacia abajo. Luego, si hay un Log Pile aliado dentro de 4″ de este modelo, puedes posicionar este modelo en contacto base con base con ese Log Pile.",
       "CST": "CP2",
       "RNG": "P",
       "SUS": false,
@@ -14228,7 +14228,7 @@
     },
     {
       "name": "Sliced Tendon",
-      "text": "El modelo oponente enemigo recibe –2/–2″ KICK y 3 DMG.",
+      "text": "El modelo enemigo objetivo recibe -2/-2″ KICK y 3 DAÑO.",
       "CST": 2,
       "RNG": 4,
       "SUS": true,
@@ -14236,7 +14236,7 @@
     },
     {
       "name": "Spring the Trap",
-      "text": "Elegí un Trap Marker dentro del alcance. Los modelos oponentes dentro de 1″ del Trap Marker elegido reciben la condición de Snared. Luego, remueve el Trap Marker de la cancha.",
+      "text": "Elige un Trap Marker dentro del alcance. Los modelos enemigos dentro de 1″ del Trap Marker elegido reciben la condición de Snared. Luego, remueve el Trap Marker de la cancha.",
       "CST": 1,
       "RNG": 4,
       "SUS": false,
@@ -14244,7 +14244,7 @@
     },
     {
       "name": "Haunting Gaze",
-      "text": "Mientras que este modelo esté en la cancha, el modelo oponente objetivo sólo se puede mover hacia este modelo cuando hace un avance.",
+      "text": "Mientras que este modelo esté en la cancha, el modelo enemigo objetivo sólo se puede mover hacia este modelo cuando hace un avance.",
       "CST": "2,CP",
       "RNG": 8,
       "SUS": true,
@@ -14252,7 +14252,7 @@
     },
     {
       "name": "Dismember",
-      "text": "Este modelo obtiene +3 DMG a la próxima Character Play que cause daño o él próximo resulta de daño de la Playbook.",
+      "text": "Este modelo obtiene +3 DAÑO a la próxima Character Play que cause daño o el próximo resultado de daño de la Playbook.",
       "CST": "1,CP",
       "RNG": "S",
       "SUS": true,
@@ -14260,7 +14260,7 @@
     },
     {
       "name": "Go For The Throat",
-      "text": "Los modelos dentro de la Melee Zone de este modelo reciben 1 DMG y la condición de Bleed.",
+      "text": "Los modelos dentro de la Melee Zone de este modelo reciben 1 DAÑO y la condición de Bleed.",
       "CST": "CP",
       "RNG": "S",
       "SUS": false,
@@ -14276,7 +14276,7 @@
     },
     {
       "name": "Gang Fighting",
-      "text": "Un modelo aliado dentro de 4″ de este modelo recibe un Push de 2″ hacia el modelo oponente objetivo.",
+      "text": "Un modelo aliado dentro de 4″ de este modelo recibe un Push de 2″ hacia el modelo enemigo objetivo.",
       "CST": "CP",
       "RNG": "P",
       "SUS": false,
@@ -14292,12 +14292,12 @@
     {
       "name": "Midas Touch",
       "active": false,
-      "text": "Cuando este modelo hace un ataque con éxito, el modelo oponente objetivo recibe la condición de Burning y la condición de Poisons."
+      "text": "Cuando este modelo hace un ataque con éxito, el modelo enemigo objetivo recibe la condición de Burning y la condición de Poison."
     },
     {
       "name": "Unpredictable Movement",
       "active": true,
-      "text": "Una vez por turno cuando un modelo oponente termina un avance dentro la Melee Zone de este modelo, este modelo puede inmediatamente hacer un Dodge de 2″."
+      "text": "Una vez por turno cuando un modelo enemigo termina un avance dentro de la Melee Zone de este modelo, este modelo puede inmediatamente hacer un Dodge de 2″."
     },
     {
       "name": "Cloud Jumper",
@@ -14307,17 +14307,17 @@
     {
       "name": "Watch The World Burn",
       "active": false,
-      "text": "Al final de la activación de este modelo, el equipo aliado obtiene 1 MP por cada modelo dentro de este pulso que tenga la condición de Burning o la condición de Poison."
+      "text": "Al final de la activación de este modelo, el equipo aliado obtiene 1 MP por cada modelo enemigo dentro de este pulso que tenga la condición de Burning o la condición de Poison."
     },
     {
       "name": "Burning Spirit",
       "active": false,
-      "text": "Los modelos oponentes que entren o terminen su activación dentro de esta aura reciben la condición de Burning."
+      "text": "Los modelos enemigos que entren o terminen su activación dentro de esta aura reciben la condición de Burning."
     },
     {
       "name": "Gimme Fuel...",
       "active": false,
-      "text": "Mientras que este modelo esté en la cancha, cuando un modelo aliado hace un ataque a un modelo oponente que tenga la condición de Burning, el modelo aliado puede ganar +2 TAC por la duración del ataque. Cada modelo aliado sólo puede beneficiarse de Me gusta la gasolina... una vez por turno."
+      "text": "Mientras que este modelo esté en la cancha, cuando un modelo aliado hace un ataque a un modelo enemigo que tenga la condición de Burning, el modelo aliado puede ganar +2 TAC por la duración del ataque. Cada modelo aliado sólo puede beneficiarse de Gimme Fuel... una vez por turno."
     },
     {
       "name": "Backdraft",
@@ -14327,22 +14327,22 @@
     {
       "name": "Furious",
       "active": false,
-      "text": "Cuando este modelo declara una carga durante su activación, puedo hacerlo sin gastar influencia."
+      "text": "Cuando este modelo declara una carga durante su activación, puede hacerlo sin gastar influencia."
     },
     {
       "name": "Inferno",
       "active": false,
-      "text": "Cuando este modelo hace un ataque con éxito, el modelo oponente objetivo recibe la condición de Burning. Los modelos oponentes detro de 2″ de este modelo que tenga la condición de Burning reciben 1 daño de condición."
+      "text": "Cuando este modelo hace un ataque con éxito, el modelo enemigo objetivo recibe la condición de Burning. Los modelos enemigos dentro de 2″ de este modelo que tengan la condición de Burning reciben 1 daño de condición."
     },
     {
       "name": "Waning Light",
       "active": false,
-      "text": "Este modelo no puede curarse PS. Cuando este modelo reciba la condición de Knocked Out, los modelos oponentes dentro de este pulso reciben 3 DAÑO de condición y la condición de Burning. Después de remover a este modelo de la cancha, reemplaza la carta de este modelo por la carta de Soma."
+      "text": "Este modelo no puede curarse PS. Cuando este modelo reciba la condición de Taken Out, los modelos enemigos dentro de este pulso reciben 3 DAÑO de condición y la condición de Burning. Después de remover a este modelo de la cancha, reemplaza la carta de este modelo por la carta de Soma."
     },
     {
       "name": "Beaker Keeper",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí un modelo aliado que no sea Capitán dentro de 4″. El modelo aliado puede usar una Character Play de CST 1 o 2 sin gastar influencia una vez durante su activación."
+      "text": "Una vez por turno durante la activación de este modelo, elige un modelo aliado que no sea Capitán dentro de 4″. El modelo aliado puede usar una Character Play de CST 1 o 2 sin gastar influencia una vez durante su activación."
     },
     {
       "name": "Light Footed",
@@ -14352,32 +14352,32 @@
     {
       "name": "Overheat",
       "active": false,
-      "text": "Cuando este modelo recibe la condición de Knocked Out durante la Fase de Activación, los modelos oponentes dentro de este pulso reciben 3 DAÑO y la condición de Burning."
+      "text": "Cuando este modelo recibe la condición de Taken Out durante la Fase de Activación, los modelos enemigos dentro de este pulso reciben 3 DAÑO y la condición de Burning."
     },
     {
       "name": "Test Subject",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro 4″. Si lo hace, este modelo puede hacer un ataque o una Character Play una vez durante su activación sin gastar influencia."
+      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, este modelo puede hacer un ataque o una Character Play una vez durante su activación sin gastar influencia."
     },
     {
       "name": "Venomous Strike",
       "active": false,
-      "text": "Los modelos oponentes dañados por este modelo reciben la condición de Poison."
+      "text": "Los modelos enemigos dañados por este modelo reciben la condición de Poison."
     },
     {
       "name": "Poisonous Fumes",
       "active": false,
-      "text": "Los modelos oponentes que entren o terminen su activación dentro de esta aura reciben la condición de Poison."
+      "text": "Los modelos enemigos que entren o terminen su activación dentro de esta aura reciben la condición de Poison."
     },
     {
       "name": "Reactive Solution",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro 4″. Si lo hace, este modelo puede hacer un ataque o una Character Play una vez durante su activación sin gastar influencia."
+      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, este modelo puede usar una Character Play una vez durante su activación sin gastar influencia."
     },
     {
       "name": "Extraction",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro 4″. Si lo hace, este modelo puede hacer inmediatamente un Dodge de 4″."
+      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, este modelo puede hacer inmediatamente un Dodge de 4″."
     },
     {
       "name": "Chemical Admixture",
@@ -14387,12 +14387,12 @@
     {
       "name": "Covalence",
       "active": false,
-      "text": "Los modelos oponentes dentro de esta aura que tenga la condición de Burning o la condición de Poison debe gastar +1 MP cuando usen Rest o sean hechos objetivo de Encourage."
+      "text": "Los modelos enemigos dentro de esta aura que tengan la condición de Burning o la condición de Poison deben gastar +1 MP cuando usen Rest o sean hechos objetivo de Encourage."
     },
     {
       "name": "Anatomical Precision",
       "active": false,
-      "text": "Cuando este modelo haga un ataque, el modelo oponente objetivo del ataque recibe -1 ARM."
+      "text": "Cuando este modelo haga un ataque, el modelo enemigo objetivo del ataque recibe -1 ARM."
     },
     {
       "name": "Deadeye",
@@ -14402,7 +14402,7 @@
     {
       "name": "Elusive",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning or condición de Poison de otro modelo dentro de 4″. so lo hace, Posiciona inmediatamente este modelo en contacto base con base del otro."
+      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, Posiciona inmediatamente este modelo en contacto base con base del otro."
     },
     {
       "name": "Burning Effigy",
@@ -14422,22 +14422,22 @@
     {
       "name": "Burst of Fumes",
       "active": false,
-      "text": "Después de que este modelo termine un ataque con éxito durante su activación, los modelos oponentes dentro de 2″ que tengan la condición de Burning o la condición de Poison reciben 1 DAÑO de condición."
+      "text": "Después de que este modelo termine un ataque con éxito durante su activación, los modelos enemigos dentro de 2″ que tengan la condición de Burning o la condición de Poison reciben 1 DAÑO de condición."
     },
     {
       "name": "Toxicity",
       "active": false,
-      "text": "Cuando un modelo oponente termina su activación en combate con este modelo, el modelo oponente recibe 2 DAÑO de condición y la condición de Poison."
+      "text": "Cuando un modelo enemigo termina su activación en combate con este modelo, el modelo enemigo recibe 2 DAÑO de condición y la condición de Poison."
     },
     {
       "name": "Witness Me!",
       "active": false,
-      "text": "Una vez por turno durante la activación de este modelo,cuando cause que un modelo oponente reciba la condición de Knocked Out, el equipo aliado obtiene +2 MP."
+      "text": "Una vez por turno durante la activación de este modelo, cuando cause que un modelo enemigo reciba la condición de Taken Out, el equipo aliado obtiene +2 MP."
     },
     {
       "name": "Debilitating Strike",
       "active": false,
-      "text": "Este modelo obtiene +2 TACcuando ataque modelos oponentes que tienen la condición de Poison."
+      "text": "Este modelo obtiene +2 TAC cuando ataque modelos enemigos que tienen la condición de Poison."
     },
     {
       "name": "Melting Body",
@@ -14452,27 +14452,27 @@
     {
       "name": "I've Been Burnt Before...",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, durante su activación puede hacer un Sprint o cargar sin gastar influencia, si no cargó o hizo un Sprinto antes de usar esta habilidad"
+      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, durante su activación puede hacer un Sprint o cargar sin gastar influencia, si no cargó o hizo un Sprint antes de usar esta habilidad."
     },
     {
       "name": "Noxious Death",
       "active": false,
-      "text": "Cuando este modelo recibe la condición de Knocked Out durante la Fase de Activación, los modelos oponentes dentro de este pulso reciben 3 DAÑO y la condición de Poison."
+      "text": "Cuando este modelo recibe la condición de Taken Out durante la Fase de Activación, los modelos enemigos dentro de este pulso reciben 3 DAÑO y la condición de Poison."
     },
     {
       "name": "Resilience",
       "active": false,
-      "text": "La primera vez que este modelo vaya a ser impactado por un ataque o Character Play, antes de activar cualquier otra habilidad, el ataque o Character Playse considera fallada y el impacto es ignorado"
+      "text": "La primera vez cada turno que este modelo vaya a ser impactado por un ataque o Character Play enemiga, antes de activar cualquier otra habilidad, el ataque o Character Play se considera fallada y el impacto es ignorado."
     },
     {
       "name": "Rush Keeper",
       "active": true,
-      "text": "Mientras que este modelo esté a 4″ del arco aliado, una vez por turno cuando uno modelo oponente termina un avance dentro de 6″ de este modelo, este modelo puede inmediatamente cargar al modelo oponente sin gastar influencia."
+      "text": "Mientras que este modelo esté a 4″ del arco aliado, una vez por turno cuando un modelo enemigo termina un avance dentro de 6″ de este modelo, este modelo puede inmediatamente cargar al modelo enemigo sin gastar influencia."
     },
     {
       "name": "Sentinel",
       "active": false,
-      "text": "Los moodelos Aprendices aliados dentro de esta aura obtienen +1 ARM."
+      "text": "Los modelos Aprendices aliados dentro de esta aura obtienen +1 ARM."
     },
     {
       "name": "Tough Hide",
@@ -14482,22 +14482,22 @@
     {
       "name": "Reduction",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, Posiciona una AOE dentro 2″ de este modelo. Los modelos aliados dentro de esta AOE se quitan todas las condiciones que tengan."
+      "text": "Una vez por turno durante la activación de este modelo, Posiciona una AOE dentro de 2″ de este modelo. Los modelos aliados dentro de esta AOE se quitan todas las condiciones que tengan."
     },
     {
       "name": "Reinforced Plating",
       "active": true,
-      "text": "Una vez por turno cuando un modelo aliado dentro de esta aura es impactado por una Character Play, el modelo impactado puede igonar todo el daño y efectos de la Character Play ."
+      "text": "Una vez por turno cuando un modelo aliado dentro de esta aura es impactado por una Character Play enemiga, el modelo impactado puede ignorar todo el daño y efectos de la Character Play."
     },
     {
       "name": "Quench",
       "active": true,
-      "text": "Cuando un modelo aliado dentro de esta aura recibe daño de una Character Play oponente, luego que la Character Playse resuelta, el modelo aliado puede curarse 1 PS."
+      "text": "Cuando un modelo aliado dentro de esta aura recibe daño de una Character Play enemiga, luego que la Character Play se resuelva, el modelo aliado puede curarse 1 PS."
     },
     {
       "name": "Give It a Whack",
       "active": false,
-      "text": "Durante su activación, si hay una pelota libre en la Melee Zone de este modelo, este modelo puedoe hacer una Kick como si estuviera en pposesión de la ball. La distancia y trayectoria de la Kick se miden desde la posición actual de la pelota libre ."
+      "text": "Durante su activación, si hay una pelota libre en la Melee Zone de este modelo, este modelo puede hacer una Kick como si estuviera en posesión de la pelota. La distancia y trayectoria de la Kick se miden desde la posición actual de la pelota libre."
     },
     {
       "name": "Get Over Here",
@@ -14512,7 +14512,7 @@
     {
       "name": "Match Experience",
       "active": true,
-      "text": "Cuando un modelo aliado dentro de esta aura usa Pase en movimiento, tanto el modelo receptor como el pateador pueden hacer un Dodge de 4″ en vez de sólo uno de los modelos."
+      "text": "Cuando un modelo aliado dentro de esta aura usa Pass & Move, tanto el modelo receptor como el pateador pueden hacer un Dodge de 4″ en vez de sólo uno de los modelos."
     },
     {
       "name": "Sturdy",
@@ -14527,37 +14527,37 @@
     {
       "name": "Arsenal",
       "active": true,
-      "text": "Si este modelo empieza su activación dentro de 6″ del modelo aliado mencionado, este modelo obtiene uno de los siguientes beneficios hasta el final del turno.\nLos beneficios a elegir son:\n- Melee Zone de 2″ \n- Capacitación\n{{play 'Instruction'}}"
+      "text": "Si este modelo empieza su activación dentro de 6″ del modelo aliado mencionado, este modelo obtiene uno de los siguientes beneficios hasta el final del turno.\nLos beneficios a elegir son:\n- Melee Zone de 2″ \n- Instruction\n{{play 'Instruction'}}"
     },
     {
       "name": "Stamina",
       "active": true,
-      "text": "Una vez por turno al comienzo de la activación de este modelo, este modelo puede hacer un trote."
+      "text": "Una vez por turno al comienzo de la activación de este modelo, este modelo puede hacer un Jog."
     },
     {
       "name": "Tutelage",
       "active": false,
-      "text": "Si empieza su activación dentro de 6″ del modelo aliado mencionado, este modelo puede use a Character Play una vez durante su activación sin gastar influencia."
+      "text": "Si empieza su activación dentro de 6″ del modelo aliado mencionado, este modelo puede usar una Character Play una vez durante su activación sin gastar influencia."
     },
     {
       "name": "Burning Passion",
       "active": false,
-      "text": "Este modelo obtiene +1 DAÑO a los resultados de daño de la Playbook cuando ataquen a un modelo oponente que tenga la condición de Burning."
+      "text": "Este modelo obtiene +1 DAÑO a los resultados de daño de la Playbook cuando ataquen a un modelo enemigo que tenga la condición de Burning."
     },
     {
       "name": "Bright Shields",
       "active": false,
-      "text": "Un modelo oponente que delcare un contraataque recibe -1 TAC mientras realice el contraataque."
+      "text": "Un modelo enemigo que declare un contraataque contra este modelo recibe -1 TAC mientras realice el contraataque."
     },
     {
       "name": "Swift Strikes",
       "active": false,
-      "text": "Durante la activación de este modelo, cuando hace daños a uno o más modelos, puede hacer un Dodge de 2″."
+      "text": "Durante la activación de este modelo, cuando hace daños a uno o más modelos enemigos, puede hacer un Dodge de 2″."
     },
     {
       "name": "Far Strike",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si un modelo oponente está dentro de 6″ de este modelo y en línea de visión, este modelo puede hacer un ataque contra el modelo oponente como si estuviera trabado en combate con ese modelo."
+      "text": "Una vez por turno durante la activación de este modelo, si un modelo enemigo está dentro de 6″ de este modelo y en línea de visión, este modelo puede hacer un ataque contra el modelo enemigo como si estuviera trabado en combate con ese modelo."
     },
     {
       "name": "Kindled",
@@ -14567,7 +14567,7 @@
     {
       "name": "Grim Vengeance",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo,cuando cause que un modelo oponente reciba la condición de Knocked Out, este modelo puede hacer un Dodge de 2″, una patado, ó un como su próxima acción sin gastar influencia."
+      "text": "Una vez por turno durante la activación de este modelo, cuando cause que un modelo enemigo reciba la condición de Taken Out, este modelo puede hacer un Dodge de 2″, una Kick, o un ataque como su próxima acción sin gastar influencia."
     },
     {
       "name": "Sweeping Charge",
@@ -14577,12 +14577,12 @@
     {
       "name": "Quick Off the Line",
       "active": true,
-      "text": "Cuando un modelo oponente hace un remate, antes que el remate sea resuelto, este modelo puede hacer un Dodge de 2″."
+      "text": "Cuando un modelo enemigo hace un Shot, antes que el Shot sea resuelto, este modelo puede hacer un Dodge de 2″."
     },
     {
       "name": "Battering Ram",
       "active": false,
-      "text": "Cuando este modelo realiza un avance, los modelos cuyas peanas queden en contacto peana con peana con la peana de este modelo reciben inmediatamente reciben un Push de 2″ alejándose directamente de este modelo. Este modelo solo puede empujar a cada modelo una vez por turno with Ariete."
+      "text": "Cuando este modelo realiza un avance, los modelos cuyas peanas queden en contacto base con base con la peana de este modelo reciben inmediatamente un Push de 2″ alejándose directamente de este modelo. Este modelo solo puede hacer Push a cada modelo una vez por turno con Battering Ram."
     },
     {
       "name": "Close Control",
@@ -14592,22 +14592,22 @@
     {
       "name": "Tryhard",
       "active": false,
-      "text": "Cuando este modelo hace un remate dentro de 2″ del arco oponente, la DT se reduce en 1."
+      "text": "Cuando este modelo hace un Shot dentro de 2″ del arco enemigo, el TN se reduce en 1."
     },
     {
       "name": "Powerful Charge",
       "active": false,
-      "text": "Durante una carga, además de uno o mmás resultados de daño de la Playbook, el modelo oponente que recibió la carga recibe la condición de Knocked Down."
+      "text": "Durante una carga, además de uno o más resultados de daño de la Playbook, el modelo enemigo que recibió la carga recibe la condición de Knocked Down."
     },
     {
       "name": "Aria",
       "active": false,
-      "text": "Los modelos aliados dentro de esta aura pueden usar Heroic Plays sin gastar MP."
+      "text": "Los otros modelos aliados del gremio dentro de esta aura pueden usar Heroic Plays sin gastar MP."
     },
     {
       "name": "Spit and Sawdust",
       "active": false,
-      "text": "Mientras que este modelo esté en la cancha, los modelos aliados se consideran trabados en combate aún cuando tengan la condición de Knocked Down."
+      "text": "Mientras que este modelo esté en la cancha, los modelos aliados del gremio se consideran trabados en combate aún cuando tengan la condición de Knocked Down."
     },
     {
       "name": "Legless Drunk",
@@ -14632,17 +14632,17 @@
     {
       "name": "Loved Creature",
       "active": false,
-      "text": "La primera vez cada turno que este modelo reciba daño de un ataque o Character Play de un modelo oponente, los demás modelos aliados obtienen +1 TAC hasta el final del turno."
+      "text": "La primera vez cada turno que este modelo reciba daño de un ataque o Character Play de un modelo enemigo, los demás modelos aliados obtienen +1 TAC hasta el final del turno."
     },
     {
       "name": "Assist",
       "active": false,
-      "text": "Cuando ataque a un modelo oponente trabado en combate por el modelo aliado mencionado, este modelo obtiene +1 TAC y +1 DAÑO a los resultados de daño de la Playbook."
+      "text": "Cuando ataque a un modelo enemigo trabado en combate por el modelo aliado mencionado, este modelo obtiene +1 TAC y +1 DAÑO a los resultados de daño de la Playbook."
     },
     {
       "name": "Defence Support",
       "active": false,
-      "text": "Este modelo obtiene +1 DEF mientras que esté dentro 4″ del modelos aliado mencionado."
+      "text": "Este modelo obtiene +1 DEF mientras que esté dentro de 4″ del modelo aliado mencionado."
     },
     {
       "name": "Shove the Boot In",
@@ -14662,17 +14662,17 @@
     {
       "name": "Taunt",
       "active": true,
-      "text": "Cuando este modelo termina un avance, elegí un modelo oponente dentro de 2″ de este modelo. El modelo oponente recibe un Push de 1″ directamente hacia este modelo."
+      "text": "Cuando este modelo termina un avance, elige un modelo enemigo dentro de 2″ de este modelo. El modelo enemigo recibe un Push de 1″ directamente hacia este modelo."
     },
     {
       "name": "Floored",
       "active": false,
-      "text": "Este modelo obtiene +2 TAC cuando realice un ataque contra un modelo que tenga la condición de Knocked Down"
+      "text": "Este modelo obtiene +2 TAC cuando realice un ataque contra un modelo que tenga la condición de Knocked Down."
     },
     {
       "name": "Football Legend",
       "active": false,
-      "text": "Los modelos aliados dentro de esta aura obtienen +1/+1″ KICK"
+      "text": "Los modelos aliados dentro de esta aura obtienen +1/+1″ KICK."
     },
     {
       "name": "Magical Brew",
@@ -14682,47 +14682,47 @@
     {
       "name": "Stack the Deck",
       "active": false,
-      "text": "Una vez por turno al comienzo de la activación de este modelo, si el equipo oponente tiene la inciativa, este modelo se aloca 1 influencia."
+      "text": "Una vez por turno al comienzo de la activación de este modelo, si el equipo enemigo tiene la iniciativa, este modelo se aloca 1 influencia."
     },
     {
       "name": "The Owner",
       "active": false,
-      "text": "Mientras que estén dentro de esta aura, los modelos aliados reciben +1 DAÑO a Character Plays que causan daño y resultados de daño de la Playbook."
+      "text": "Mientras que estén dentro de esta aura, los modelos aliados del gremio obtienen +1 DAÑO a Character Plays que causan daño y resultados de daño de la Playbook."
     },
     {
       "name": "Haemophilia",
       "active": false,
-      "text": "En la fase final, antes que se resuelvan las condiciones, este modelo puede curarse 1 PS por cada modelo oponente que tenga la condición de Bleed."
+      "text": "En la Fase Final, antes que se resuelvan las condiciones, este modelo puede curarse 1 PS por cada modelo enemigo que tenga la condición de Bleed."
     },
     {
       "name": "Smell Blood",
       "active": false,
-      "text": "Este modelo obtiene +2″ /+2″ MOV Mientras dura la carga cuando cargue a un modelo que tenga la condición de Bleed. Este modelo obtiene +1 DAÑO a los resultados de daño de la Playbook contra modelos oponentes que tengan la condición de Bleed"
+      "text": "Este modelo obtiene +2″/+2″ MOV mientras dura la carga cuando cargue a un modelo que tenga la condición de Bleed. Este modelo obtiene +1 DAÑO a los resultados de daño de la Playbook contra modelos enemigos que tengan la condición de Bleed."
     },
     {
       "name": "Berserk",
       "active": false,
-      "text": "Durante su activación, si este modelo le hace daños a un modelo oponente con un ataque, este modelo puede hacer un ataque sin gastar influencia. Este habilidad sólo puede generar un ataque por si misma."
+      "text": "Durante su activación, si este modelo le hace daños a un modelo enemigo con un ataque, este modelo puede hacer un ataque sin gastar influencia. Esta habilidad sólo puede generar un ataque por si misma."
     },
     {
       "name": "Blood Lust",
       "active": false,
-      "text": "Una vez por turno un modelo aliado que empiece su activación dentro de esta aura puede gastar 1 influencia para obtener Colérico hasta el final del turno."
+      "text": "Una vez por turno cuando otro modelo aliado empiece su activación dentro de esta aura, puede gastar 1 influencia para obtener Berserk hasta el final del turno."
     },
     {
       "name": "Vicious",
       "active": false,
-      "text": "Este modelo obtiene +2 TAC y +1 DAÑO a los resultados de daño de la Playbook cuando hace ataque de oportunidad ."
+      "text": "Este modelo obtiene +2 TAC y +1 DAÑO a los resultados de daño de la Playbook cuando hace Parting Blow."
     },
     {
       "name": "Vindictive",
       "active": false,
-      "text": "Durante su activación, este modelo puede cagar gastando 1 linfluencia menos"
+      "text": "Durante su activación, este modelo puede cargar gastando 1 influencia menos."
     },
     {
       "name": "Life Drinker",
       "active": false,
-      "text": "Cuando este modelo dañe a un modelo oponente con uno o más resultados de daño de la Playbook, este modelo puede curarse 1 PS."
+      "text": "Cuando este modelo dañe a un modelo enemigo con uno o más resultados de daño de la Playbook, este modelo puede curarse 1 PS."
     },
     {
       "name": "Crucial Artery",
@@ -14737,22 +14737,22 @@
     {
       "name": "Field Medic",
       "active": true,
-      "text": "Durante la activación de este modelo, cuando daña a un modelo oponente, elegí un modelo aliado dentro de esta aura sacale todas las condiciones que tenga."
+      "text": "Durante la activación de este modelo, cuando daña a un modelo enemigo, elige un modelo aliado dentro de esta aura y sácale todas las condiciones que tenga."
     },
     {
       "name": "Pragmatic",
       "active": false,
-      "text": "Durante su activación, este modelo puede cagar y hacer pases gastando 1 linfluencia menos"
+      "text": "Durante su activación, este modelo puede cargar y hacer pases gastando 1 influencia menos."
     },
     {
       "name": "Bleed the Cleats",
       "active": false,
-      "text": "Cada vez que este modelo hace daño a un modelo oponente, este modelo obtiene +1/+0″ KICK hasta el final del turno."
+      "text": "Cada vez que este modelo hace daño a un modelo enemigo, este modelo obtiene +1/+0″ KICK hasta el final del turno."
     },
     {
       "name": "Get On With It, Boy!",
       "active": true,
-      "text": "Si este modelo empieza su activación dentro de 6″ del modelo aliado mencionado, este modelo puede inmediatamente usar una Character Playsin gastar influencia or sacarse todas las condiciones que tenga."
+      "text": "Si este modelo empieza su activación dentro de 6″ del modelo aliado mencionado, este modelo puede inmediatamente usar una Character Play sin gastar influencia o sacarse todas las condiciones que tenga."
     },
     {
       "name": "Magic Touch",
@@ -14762,17 +14762,17 @@
     {
       "name": "Hooked",
       "active": false,
-      "text": "Los modelos enemigos dañados por este modelo reciben la condición de Bleed y la condición de atrapado."
+      "text": "Los modelos enemigos dañados por este modelo reciben la condición de Bleed y la condición de Snared."
     },
     {
       "name": "Lash Out",
       "active": false,
-      "text": "Cuando este modelo termine su activación, los modelos oponentes dentro de la Melee Zone de este modelo reciben 3 DAÑO."
+      "text": "Cuando este modelo termine su activación, los modelos enemigos dentro de la Melee Zone de este modelo reciben 3 DAÑO."
     },
     {
       "name": "The Old Ways",
       "active": false,
-      "text": "Una vez por turno, cuando este modelo hace que un modelo oponente reciba la condición de Knocked Out, este modelo obtiene The Owner [Aura de 6″] hasta el final del turno.\n{{trait 'The Owner'}}"
+      "text": "Una vez por turno, cuando este modelo hace que un modelo enemigo reciba la condición de Taken Out, este modelo obtiene The Owner [Aura de 6″] hasta el final del turno.\n{{trait 'The Owner'}}"
     },
     {
       "name": "Damaged Target",
@@ -14782,12 +14782,12 @@
     {
       "name": "Goal Defence",
       "active": false,
-      "text": "Los modelos oponentes reciben +1 DT a los remates mientras que este modelo esté a 4″ del arco aliado."
+      "text": "Los modelos enemigos reciben +1 TN a los Shots mientras que este modelo esté a 4″ del arco aliado."
     },
     {
       "name": "Guild Rule: Intimidation",
       "active": false,
-      "text": "Los modelos oponentes reciben -1 DEF cuando sean atacados por un modelo con esta Guild Rule."
+      "text": "Los modelos enemigos reciben -1 DEF cuando sean atacados por un modelo con esta Guild Rule."
     },
     {
       "name": "Scathing Rebuke",
@@ -14797,27 +14797,27 @@
     {
       "name": "Big Belly",
       "active": true,
-      "text": "Cuando un modelo oponente daña a este modelo con uno o más resultados de daño de la Playbook, después de resolver el ataque, el modelo oponente recibe un Push de 1″ alejándose directamente de este modelo."
+      "text": "Cuando un modelo enemigo daña a este modelo con uno o más resultados de daño de la Playbook, después de resolver el ataque, el modelo enemigo recibe un Push de 1″ alejándose directamente de este modelo."
     },
     {
       "name": "Icing on the Cake",
       "active": false,
-      "text": "Este modelo obtiene +2/+2″ KICK cuando hace un Remate de Primera."
+      "text": "Este modelo obtiene +2/+2″ KICK cuando hace un Snap Shot."
     },
     {
       "name": "Momentous Inspiration",
       "active": false,
-      "text": "Cuando un modelo aliado dentro de esta aura impacte a un modelo oponente con una Character Play que causa daño, luego de resolver la Character Play el equipo aliado recibe 1 MP. Los modelos aliados dentro de esta aura pueden usar Tiempo Extra sin gastar MP una vez por Character Play ."
+      "text": "Cuando un modelo aliado dentro de esta aura impacte a un modelo enemigo con una Character Play que causa daño, luego de resolver la Character Play el equipo aliado recibe 1 MP. Los modelos aliados dentro de esta aura pueden usar Tiempo Extra sin gastar MP una vez por Character Play."
     },
     {
       "name": "Reanimate",
       "active": true,
-      "text": "Una vez por turno cuando los PS de este modelo lleguen a 0, antes de recibir la condición de noqueadao, puede curarse 3 PS y quitarse todas las condiciones que tenga."
+      "text": "Una vez por turno cuando los PS de este modelo lleguen a 0, antes de recibir la condición de Taken Out, puede curarse 3 PS y quitarse todas las condiciones que tenga."
     },
     {
       "name": "Well Oiled Machine",
       "active": false,
-      "text": "Una vez por turno cuando un modelo aliado recibe un paso con éxito, el modelo aliado puede inmediatamente hacer un pase sin gastar influencia en vez de usar Pase en movimiento o hacer un Remate de Primera."
+      "text": "Una vez por turno cuando un modelo aliado recibe un pase con éxito, el modelo aliado puede inmediatamente hacer un pase sin gastar influencia en vez de usar Pass & Move o hacer un Snap Shot."
     },
     {
       "name": "Follow My Lead",
@@ -14827,27 +14827,27 @@
     {
       "name": "Tow",
       "active": true,
-      "text": "Al final de un avance que haya hecho este modelo durante su activación, los modelos aliados que hayan estado dentro de 2″ des este modelo mienetras avanzaba pueden hacer un Jog directamente hacia este modelo."
+      "text": "Al final de un avance que haya hecho este modelo durante su activación, los modelos aliados que hayan estado dentro de 2″ de este modelo mientras avanzaba pueden hacer un Jog directamente hacia este modelo."
     },
     {
       "name": "Launch Control",
       "active": true,
-      "text": "Una vez por turno durante su activación, este modelo puede usar Centro al área y hacer un pase sin gastar influencia."
+      "text": "Una vez por turno durante su activación, este modelo puede usar Long Bomb y hacer un pase sin gastar influencia."
     },
     {
       "name": "Spider Nests",
       "active": true,
-      "text": "Una vez por turno durante su activación, este modelo puede posicionar un marcador de nido aliado de 30mm dentro de 4″. Un jugador puede tener hasta tres marcadores de nido aliados en la cancha al mismo tiempo. Cuando un modelo se mueve en contacto peana con peana con un marcador de nido cuando haga un Sprint o una carga, el marcador de nido se quita de la cancha"
+      "text": "Una vez por turno durante su activación, este modelo puede posicionar un marcador de nido aliado de 30mm dentro de 4″. Un jugador puede tener hasta tres marcadores de nido aliados en la cancha al mismo tiempo. Cuando un modelo se mueve en contacto base con base con un marcador de nido cuando haga un Sprint o una carga, el marcador de nido se quita de la cancha."
     },
     {
       "name": "Spiderlings",
       "active": false,
-      "text": "Los modelos oponentes que estén dentro de 1″ de uno o más marcadores de nido reciben la penalización de encierro."
+      "text": "Los modelos enemigos que estén dentro de 1″ de uno o más marcadores de nido reciben la penalización de encierro."
     },
     {
       "name": "Webbing",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si hay un marcador de nido aliado dentro 4″ de este modelo y dentro de 2″ de una pelota libre, este modelo puede ganar posesión de la pelota."
+      "text": "Una vez por turno durante la activación de este modelo, si hay un marcador de nido aliado dentro de 4″ de este modelo y dentro de 2″ de una pelota libre, este modelo puede ganar posesión de la pelota."
     },
     {
       "name": "Stoic",
@@ -14857,27 +14857,27 @@
     {
       "name": "If You Can Dodge a Wrench...",
       "active": false,
-      "text": "Cuando este modelo dañe a un modelo oponente que tenga posesión de la pelota, el modelo oponente pierde posesión de la pelota. Hacé una dispersión circular con la plantilla centrada en el modelo oponente objetivo de esta Character Play ."
+      "text": "Cuando este modelo dañe a un modelo enemigo que tenga posesión de la pelota, el modelo enemigo pierde posesión de la pelota. Haz una dispersión circular con la plantilla centrada en el modelo enemigo objetivo de esta Character Play."
     },
     {
       "name": "Inspiring Hat",
       "active": false,
-      "text": "Los demás modelos aliados dentro de esta aura pueden gastar 1 MP menos para usar Pase en movimiento o hacer un Remate de Primera."
+      "text": "Los demás modelos aliados dentro de esta aura pueden gastar 1 MP menos para usar Pass & Move o hacer un Snap Shot."
     },
     {
       "name": "Learn From The Best",
       "active": false,
-      "text": "Si este modelo empieza su activación dentro 4″ de un modelo aliado  del tipo mencionado, este modelo puede use una Character Play una vez durante su activación sin gastar influencia."
+      "text": "Si este modelo empieza su activación dentro de 4″ de un modelo aliado del tipo mencionado, este modelo puede usar una Character Play una vez durante su activación sin gastar influencia."
     },
     {
       "name": "True Replication",
       "active": true,
-      "text": "Este modelo puede usar Character Plays de los modelos aliado que no sean capitán dentro de esta aura as como si estuvieran en la carta de este modelo. Cuando este modelo use una Character Play que haga daño, se vuelve OPT ✔ y su RNG se reduce en 2″."
+      "text": "Este modelo puede usar Character Plays de los modelos aliados que no sean Capitán dentro de esta aura como si estuvieran en la carta de este modelo. Cuando este modelo use una Character Play que haga daño, se vuelve OPT ✔ y su RNG se reduce en 2″."
     },
     {
       "name": "Gravity Well",
       "active": true,
-      "text": "Cuando un modelo oponente termina un avance trabado en combate con este modelo, el modelo oponente inmediatamente recibe un Push de 2″ directamente hacia este modelo."
+      "text": "Cuando un modelo enemigo termina un avance trabado en combate con este modelo, el modelo enemigo inmediatamente recibe un Push de 2″ directamente hacia este modelo."
     },
     {
       "name": "Goal of the Month",
@@ -14887,7 +14887,7 @@
     {
       "name": "Roulette",
       "active": true,
-      "text": "Al comienzo de la activación de este modelo, elegí un efecto. El efecto elegido dura hasta el final de la activación de este modelo.\n- Este modelo obtiene +1″ /+1″ MOV.\n- Este modelo obtiene +1 TAC.\n- Este modelo obtiene +0/+2″ KICK"
+      "text": "Al comienzo de la activación de este modelo, elige un efecto. El efecto elegido dura hasta el final de la activación de este modelo.\n- Este modelo obtiene +1″ /+1″ MOV.\n- Este modelo obtiene +1 TAC.\n- Este modelo obtiene +0/+2″ KICK."
     },
     {
       "name": "Fixer",
@@ -14897,12 +14897,12 @@
     {
       "name": "Lend a Hand",
       "active": false,
-      "text": "Cuando un modelo aliado  recibe el bono de apoyo este modelo, el modelo aliado obtiene un +1 TAC adicional."
+      "text": "Cuando un modelo aliado recibe el bono de apoyo este modelo, el modelo aliado obtiene un +1 TAC adicional."
     },
     {
       "name": "Death from Above",
       "active": true,
-      "text": "Durante su activación, si un modelo oponente este dentro de 6″ de este modelo, en la linea de visión de este modelo, y dentro una AOE de Bandada, este modelo puede hacer un ataque contra el modelo oponente como si estuviese trabado en combate. Este ataque obtiene +5 TAC. Desués de resolver este ataquem remueve el AOE de Bandada de la cancha."
+      "text": "Durante su activación, si un modelo enemigo está dentro de 6″ de este modelo, en la línea de visión de este modelo, y dentro de una AOE de Harrier, este modelo puede hacer un ataque contra el modelo enemigo como si estuviese trabado en combate. Este ataque obtiene +5 TAC. Después de resolver este ataque, remueve el AOE de Harrier de la cancha."
     },
     {
       "name": "Flying",
@@ -14912,27 +14912,27 @@
     {
       "name": "Hunter's Prey",
       "active": false,
-      "text": "Los modelos enemigos dañados por este modelo reciben la condición de atrapado."
+      "text": "Los modelos enemigos dañados por este modelo reciben la condición de Snared."
     },
     {
       "name": "Feathered Friends",
       "active": false,
-      "text": "Este modelo recibe +1 TAC y cobertura mientras que este dentro de una AOE aliada de Bandada AOE."
+      "text": "Este modelo obtiene +1 TAC y cobertura mientras esté dentro de una AOE aliada de Harrier."
     },
     {
       "name": "Hawk Eye",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si hay un modelo oponente dentro de 6″ de este modelo y en línea de visión, este modelo puede hacer un ataque sin gastar influencia contra el modelo oponente como si estuviera trabado en combate."
+      "text": "Una vez por turno durante la activación de este modelo, si hay un modelo enemigo dentro de 6″ de este modelo y en línea de visión, este modelo puede hacer un ataque sin gastar influencia contra el modelo enemigo como si estuviera trabado en combate."
     },
     {
       "name": "Nocturnal Hunting",
       "active": true,
-      "text": "Si un modelo oponente recibe la condición de Knocked Out dentro de esta aura, despúes de resolver la acción en curso, este modelo puede usar Encourage sin gastar MP."
+      "text": "Si un modelo enemigo recibe la condición de Taken Out dentro de esta aura, después de resolver la acción en curso, este modelo puede usar Encourage sin gastar MP."
     },
     {
       "name": "For the Family",
       "active": false,
-      "text": "Mientras que estén dentro de esta aura, los modelos aliados reciben +1/+2″ KICK."
+      "text": "Mientras que estén dentro de esta aura, los modelos aliados del gremio obtienen +1/+2″ KICK."
     },
     {
       "name": "Planting Master",
@@ -14957,12 +14957,12 @@
     {
       "name": "Pain Response",
       "active": false,
-      "text": "Una vez por turno cuando este modelo reciba daño puede hacer un trote, excepto si recibió el daño durante un avance, ."
+      "text": "Una vez por turno cuando este modelo reciba daño puede hacer un Jog, excepto si recibió el daño durante un avance."
     },
     {
       "name": "Ass Kicking",
       "active": true,
-      "text": "Una vez por turno cuando este modelo hace un ataque con éxito, después de resolver los resultados de la Playbook, el modelo oponente objetivo recibe un Push de 4″ alejándose directamente de este modelo."
+      "text": "Una vez por turno cuando este modelo hace un ataque con éxito, después de resolver los resultados de la Playbook, el modelo enemigo objetivo recibe un Push de 4″ alejándose directamente de este modelo."
     },
     {
       "name": "Carrot & Stick",
@@ -14977,27 +14977,27 @@
     {
       "name": "One of Our Own",
       "active": false,
-      "text": "La primera vez que un modelo aliado que no sea Mascota reciba la condición de Knocked Out dentro de esta aura, este modelo obtiene +2 TAC hasta el final del turno."
+      "text": "La primera vez que un modelo aliado que no sea Mascota reciba la condición de Taken Out dentro de esta aura, este modelo obtiene +2 TAC hasta el final del turno."
     },
     {
       "name": "Cabbage Punt",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede elegir un Harvest Marker aliado dentro de 2″ y removerlo de la cancha. Si lo hace, este modelo puede then use a Character Play una vez durante su activación sin gastar influencia."
+      "text": "Una vez por turno durante la activación de este modelo, puede elegir un Harvest Marker aliado dentro de 2″ y removerlo de la cancha. Si lo hace, este modelo puede usar una Character Play una vez durante su activación sin gastar influencia."
     },
     {
       "name": "Between a Rock...",
       "active": true,
-      "text": "Una vez por turno cuando un modelo aliado dentro de esta aura recibe daño de un ataque o Character Play este modelo puede hacer trote, excepto si el modelo aliado recibió el daño mientras realizaba un avance."
+      "text": "Una vez por turno cuando otro modelo aliado dentro de esta aura recibe daño de un ataque o Character Play enemiga, este modelo puede hacer un Jog, excepto si el modelo aliado recibió el daño mientras realizaba un avance."
     },
     {
       "name": "Making Hay",
       "active": true,
-      "text": "Al comienzo de la activación de este modelo, puede remover cualquier cantidad de marcadores de cosecha aliados de la cancha que estén dentro de 4″. Este modelo es alocado 2 influencia por caada Harvest Marker aliado removido de esta forma."
+      "text": "Al comienzo de la activación de este modelo, puede remover cualquier cantidad de marcadores de cosecha aliados de la cancha que estén dentro de 4″. Este modelo es alocado 2 influencia por cada Harvest Marker aliado removido de esta forma."
     },
     {
       "name": "Protective Instinct",
       "active": false,
-      "text": "Los modelos oponentes no puede hacer ataques contra otro modelo aliado mientras estén trabados en combate con este modelo."
+      "text": "Los modelos enemigos no pueden hacer ataques contra otro modelo aliado mientras estén trabados en combate con este modelo."
     },
     {
       "name": "With Age Comes Wisdom",
@@ -15012,12 +15012,12 @@
     {
       "name": "Rapid Growth",
       "active": false,
-      "text": "Durante la Fase Final, antes que se resuelvan las condiciones, los modelos aliados dentro de esta aura may curarse 2 PS."
+      "text": "Durante la Fase Final, antes que se resuelvan las condiciones, los modelos aliados dentro de esta aura pueden curarse 2 PS."
     },
     {
       "name": "Faithful Protector",
       "active": false,
-      "text": "Los modelos oponentes reciben -1 TAC cuando ataquen a este modelo."
+      "text": "Los modelos enemigos reciben -1 TAC cuando ataquen a este modelo."
     },
     {
       "name": "Fields of Wheat",
@@ -15037,12 +15037,12 @@
     {
       "name": "Take One for the Team",
       "active": true,
-      "text": "Una vez por turno cuando un modelo aliado  dentro de esta aura reciba cualquier condición, excepto la condición de Knocked Out, que este modelo no tenga, este modelo puede recibir esa condición en vez de recibirla el modelo aliado."
+      "text": "Una vez por turno cuando un modelo aliado del gremio dentro de esta aura reciba cualquier condición, excepto la condición de Taken Out, que este modelo no tenga, este modelo puede recibir esa condición en vez de recibirla el modelo aliado."
     },
     {
       "name": "Fertile Soil",
       "active": true,
-      "text": "Una vez por turno cuando un modelo aliado  posiciona uno o más marcadores de cosecha aliados dentro de esta aura, Posiciona un Harvest Marker aliado adicional dentro de esta aura."
+      "text": "Una vez por turno cuando un modelo aliado posiciona uno o más marcadores de cosecha aliados dentro de esta aura, Posiciona un Harvest Marker aliado adicional dentro de esta aura."
     },
     {
       "name": "True Path",
@@ -15052,12 +15052,12 @@
     {
       "name": "Fork Off!",
       "active": true,
-      "text": "Una vez por turno cuando uno modelo oponente termina un avance dentro de 6″ de este modelo, si este modelo no esta trabado en combate puede inmediatamente remover un Harvest Marker aliado dentro de 2″ para declarar una carga al modelo oponete sin gastar influencia."
+      "text": "Una vez por turno cuando un modelo enemigo termina un avance dentro de 6″ de este modelo, si este modelo no está trabado en combate puede inmediatamente remover un Harvest Marker aliado dentro de 2″ para declarar una carga al modelo enemigo sin gastar influencia."
     },
     {
       "name": "Make It Rain",
       "active": false,
-      "text": "Este modelo puede elegir resultados de íconos en la Playbook cuando hace un ataque de oportunidad."
+      "text": "Este modelo puede elegir resultados de íconos en la Playbook cuando hace un Parting Blow."
     },
     {
       "name": "Big Breakfast",
@@ -15067,12 +15067,12 @@
     {
       "name": "Empathy",
       "active": false,
-      "text": "Los resultados de daño de la Playbook de los ataques de modelos oponentes generan MP."
+      "text": "Mientras ataquen a este modelo, los resultados de daño de la Playbook no generan MP."
     },
     {
       "name": "Coup de Grâce",
       "active": false,
-      "text": "Una vez por turno cuando un modelo oponente recibe la condición de Knocked Out dentro de esta aura, el equipo aliado obtiene +3 MP."
+      "text": "Una vez por turno cuando un modelo enemigo recibe la condición de Taken Out dentro de esta aura, el equipo aliado obtiene +3 MP."
     },
     {
       "name": "Last Cast Catches the Most",
@@ -15082,7 +15082,7 @@
     {
       "name": "Beating Wings Over Water",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí otro modelo aliado dentro de 8″. El modelo elegido obtiene Flying.\n{{trait 'Flying'}}"
+      "text": "Una vez por turno durante la activación de este modelo, elige otro modelo aliado dentro de 8″. El modelo elegido obtiene Flying.\n{{trait 'Flying'}}"
     },
     {
       "name": "Tag Along",
@@ -15092,12 +15092,12 @@
     {
       "name": "Fear",
       "active": false,
-      "text": "La primera vez cada turno que un modelo oponente gasta influencia par hacer un ataque, carga o Character Play contra este modelo, el modelo oponente debe gastar 1 influencia adicional."
+      "text": "La primera vez cada turno que un modelo enemigo gasta influencia para hacer un ataque, carga o Character Play contra este modelo, el modelo enemigo debe gastar 1 influencia adicional."
     },
     {
       "name": "Talisman",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede usar una Character Playsin gastar influencia."
+      "text": "Una vez por turno durante la activación de este modelo, puede usar una Character Play sin gastar influencia."
     },
     {
       "name": "Resolute",
@@ -15112,12 +15112,12 @@
     {
       "name": "Close Ranks",
       "active": false,
-      "text": "Cuando este modelo hace que un modelo ooponente reciba la penalización de encierro, el modelo oponente recibe an un -1 dado adicional a su tirada."
+      "text": "Cuando este modelo hace que un modelo enemigo reciba la penalización de encierro, el modelo enemigo recibe un -1 dado adicional a su tirada."
     },
     {
       "name": "Lightning Reflexes",
       "active": true,
-      "text": "Una vez por turno when an enemy modelo termine un Dodge dentro de esta aura, este modelo puede inmediatamente hacer un Jog directamente hacia el modelo oponente ."
+      "text": "Una vez por turno cuando un modelo enemigo termina un Dodge dentro de esta aura, este modelo puede inmediatamente hacer un Jog directamente hacia el modelo enemigo."
     },
     {
       "name": "Cover of Darkness",
@@ -15132,7 +15132,7 @@
     {
       "name": "Bag of Coffers",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí un modelo aliado que no sea Capitán dentro de 4″. El modelo elegido es alocado 1 influencia y puede usar Tiempo Extra una vez durante su activación sin gastar MP."
+      "text": "Una vez por turno durante la activación de este modelo, elige un modelo aliado que no sea Capitán dentro de 4″. El modelo elegido es alocado 1 influencia y puede usar Tiempo Extra una vez durante su activación sin gastar MP."
     },
     {
       "name": "Beautiful",
@@ -15147,7 +15147,7 @@
     {
       "name": "Escaping Fate",
       "active": true,
-      "text": "Una vez por turno cuando los PS de este modelo lleguen a 0, excepto mientras hace un avance, antes de recibir la condición de Knocked Out pueden curarse 1 PS, quitarse todas las condiciones, y hacer un Dodge de 2″."
+      "text": "Una vez por turno cuando los PS de este modelo lleguen a 0, excepto mientras hace un avance, antes de recibir la condición de Taken Out pueden curarse 1 PS, quitarse todas las condiciones, y hacer un Dodge de 2″."
     },
     {
       "name": "Nature's Growth",
@@ -15157,7 +15157,7 @@
     {
       "name": "Nature's Chill",
       "active": true,
-      "text": "Al comienzo de la activación de este modelo, puede posicionar una AOE dentro de 8″ sin posicionarla en contacto con una pieza de escenografía. La AOE es un terreno rápido y es removida durante la Fase Final.."
+      "text": "Al comienzo de la activación de este modelo, puede posicionar una AOE dentro de 8″ sin posicionarla en contacto con una pieza de escenografía. La AOE es un terreno rápido y es removida durante la Fase Final."
     },
     {
       "name": "Bring Them Down",
@@ -15167,22 +15167,22 @@
     {
       "name": "Expert Trapper",
       "active": false,
-      "text": "Mientras que este modelo esté en la cancha, cuando un modelo oponenteactivaun Trap Marker, elegí un efecto adicional:\n- el modelo oponente recibe Punto Débil.\n- el modelo oponente recibe la condición de Bleed."
+      "text": "Mientras que este modelo esté en la cancha, cuando un modelo enemigo active un Trap Marker, elige un efecto adicional:\n- El modelo enemigo recibe Weak Point.\n- El modelo enemigo recibe la condición de Bleed."
     },
     {
       "name": "Isolated Target",
       "active": false,
-      "text": "Este modelo obtiene +1 DAÑO a los resultados de daño de la Playbook cuando ataque aun modelo oponente que tenga la condición de atrapado."
+      "text": "Este modelo obtiene +1 DAÑO a los resultados de daño de la Playbook cuando ataque a un modelo enemigo que tenga la condición de Snared."
     },
     {
       "name": "Linked",
       "active": true,
-      "text": "Cuando la activación de este modelo termina, el modelo mencionado puede activar inmediatemente en caso de que pueda"
+      "text": "Cuando la activación de este modelo termina, el modelo mencionado puede activar inmediatamente en caso de que pueda."
     },
     {
       "name": "Pack Mentality",
       "active": true,
-      "text": "Cuando otro modelo aliado dentro de esta aura que no renga la condición de Knocked Down recibe daño de un ataque o Character Play oponente, puede hacer un Dodge de 1″ directamente hacia este modelo."
+      "text": "Cuando otro modelo aliado dentro de esta aura que no tenga la condición de Knocked Down recibe daño de un ataque o Character Play enemiga, puede hacer un Dodge de 1″ directamente hacia este modelo."
     },
     {
       "name": "Big Game Traps",
@@ -15192,42 +15192,42 @@
     {
       "name": "Unorthodox",
       "active": false,
-      "text": "Cuando este modelo hace un ataque exitoso contra un modelo que tenga la condición de atrapado, puede agregar un {{dd}} a los resultados de la Playbook."
+      "text": "Cuando este modelo hace un ataque exitoso contra un modelo que tenga la condición de Snared, puede agregar un {{dd}} a los resultados de la Playbook."
     },
     {
       "name": "Mirage",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si este modelo está dentro de terreno difícil, terreno rápido o un bosque este modelo puede ser posicionado en cualquier lugar dentro de esa pieza de escenografía"
+      "text": "Una vez por turno durante la activación de este modelo, si este modelo está dentro de terreno difícil, terreno rápido o un bosque este modelo puede ser posicionado en cualquier lugar dentro de esa pieza de escenografía."
     },
     {
       "name": "Nature's Blessing",
       "active": true,
-      "text": "Una vez por turno durante su activación, este modelo puede elegir un bosque dentro de 4″. Este modelo puede ser posicionado el cualquier lugar dentro de bosque"
+      "text": "Una vez por turno durante su activación, este modelo puede elegir un bosque dentro de 4″. Este modelo puede ser posicionado en cualquier lugar dentro del bosque."
     },
     {
       "name": "Last Light",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí un modelo aliado dentro de 6″. El modelo elegido puede gastar MP en vez de  influencia para pagar el CST de una Character Play una vez durante este turno."
+      "text": "Una vez por turno durante la activación de este modelo, elige un modelo aliado dentro de 6″. El modelo elegido puede gastar MP en vez de influencia para pagar el CST de una Character Play una vez durante este turno."
     },
     {
       "name": "Lunar Eclipse",
       "active": true,
-      "text": "Cada vez que este modelo impacte a un modelo oponente con un ataque o Character Play, después de resolver la acción este modelo puede ser posicionado dentro de 1″ del modelo oponente."
+      "text": "Cada vez que este modelo impacte a un modelo enemigo con un ataque o Character Play, después de resolver la acción este modelo puede ser posicionado dentro de 1″ del modelo enemigo."
     },
     {
       "name": "Winter's Blessing",
       "active": false,
-      "text": "Cuando este modelo hace un avance, ignora la penalización al MOV por terreno difícil. Cuando este modelo se mueve dentro de una o más terrenos difíciles en un avance, obtiene +2″ /+2″ MOV mientas dure el avance."
+      "text": "Cuando este modelo hace un avance, ignora la penalización al MOV por terreno difícil. Cuando este modelo se mueve dentro de una o más terrenos difíciles en un avance, obtiene +2″ /+2″ MOV mientras dure el avance."
     },
     {
       "name": "Heightened Senses",
       "active": false,
-      "text": "Los modelos oponentes dañados reciben -1 TAC cuando ataque a este modelo."
+      "text": "Los modelos enemigos dañados reciben -1 TAC cuando ataquen a este modelo."
     },
     {
       "name": "Ambush",
       "active": false,
-      "text": "Cuando sean cargados por este modelo, los modelos oponentes deben gastar un +1 MP para usar Postura Defensiva."
+      "text": "Cuando sean cargados por este modelo, los modelos enemigos deben gastar un +1 MP para usar Postura Defensiva."
     },
     {
       "name": "Lone Hunter",
@@ -15237,37 +15237,37 @@
     {
       "name": "Knockback",
       "active": false,
-      "text": "Cuando este modelo hace un ataque con éxito, después de resolver los resultados de la Playbook, el modelo oponente objetivo recibe un Push de 1″ alejándose directamente de este modelo. Este modelo puede luego hacer un Dodge de 1″ directamente hacia el modelo oponente ."
+      "text": "Cuando este modelo hace un ataque con éxito, después de resolver los resultados de la Playbook, el modelo enemigo objetivo recibe un Push de 1″ alejándose directamente de este modelo. Este modelo puede luego hacer un Dodge de 1″ directamente hacia el modelo enemigo."
     },
     {
       "name": "Making Space",
       "active": true,
-      "text": "Mientras que este modelo esté en la cancha, una vez por activación cuando un modelo aliado hace un pase, antes de elegir el receptor, otro modelo aliado puede hacer un Dodge de 4″. Cada modelo aliado solo puede hacer un Dodge una vez por turno por efecto de Abriendo la cancha."
+      "text": "Mientras que este modelo esté en la cancha, una vez por activación cuando un modelo aliado del gremio hace un pase, antes de elegir el receptor, otro modelo aliado del gremio puede hacer un Dodge de 4″. Cada modelo aliado solo puede hacer un Dodge una vez por turno por efecto de Making Space."
     },
     {
       "name": "Counter-Charge",
       "active": false,
-      "text": "Una vez por turno cuando un modelo oponente termina un avance dentro de 6″ de este modelo, este modelo puede inmediatamente cargar al modelo opononente sin gastar influencia."
+      "text": "Una vez por turno cuando un modelo enemigo termina un avance dentro de 6″ de este modelo, este modelo puede inmediatamente cargar al modelo enemigo sin gastar influencia."
     },
     {
       "name": "Follow Up",
       "active": true,
-      "text": "Cuando un modelo oponente termina un avance que hace que salga de la Melee Zone de este modelo, este modelo puede inmediatamente hacer un Jog directamente hacia el modelo oponente ."
+      "text": "Cuando un modelo enemigo termina un avance que hace que salga de la Melee Zone de este modelo, este modelo puede inmediatamente hacer un Jog directamente hacia el modelo enemigo."
     },
     {
       "name": "Put Me Back In, Coach!",
       "active": true,
-      "text": "Una vez por turno cuando este modelo recibe la condición de Knocked Out, este modelo puede inmediatamente remover la condición de Knocked Out y volver a la cancha como si fuera la Fase de Mantenimiento."
+      "text": "Una vez por turno cuando este modelo recibe la condición de Taken Out, este modelo puede inmediatamente remover la condición de Taken Out y volver a la cancha como si fuera la Fase de Mantenimiento."
     },
     {
       "name": "Revelling",
       "active": false,
-      "text": "Una vez por turno cuando este modelo hace que un modelo oponente reciba la condición de Knocked Out, este modelo obtiene +2 ARM hasta el final del turno."
+      "text": "Una vez por turno cuando este modelo hace que un modelo enemigo reciba la condición de Taken Out, este modelo obtiene +2 ARM hasta el final del turno."
     },
     {
       "name": "Adaptive Strategy",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí otro modelo aliado dentro de este pulso. remueve cualquier cantidad de influcnecia de un modelo aliado y alócala en el modelo elegido."
+      "text": "Una vez por turno durante la activación de este modelo, elige otro modelo aliado dentro de este pulso. Remueve cualquier cantidad de influencia de un modelo aliado y alócala en el modelo elegido."
     },
     {
       "name": "Family",
@@ -15282,7 +15282,7 @@
     {
       "name": "Team Player",
       "active": false,
-      "text": "Cuando un modelo aliado dentro de esta aura reciba daño, este modelo puede recibir el daño en su lugar. Cuando este modelo reciba daño por usar Juega en equipo, todo el daño que exceda los PS de este modelo se le hace al modelo que recibió el ataque."
+      "text": "Cuando un modelo aliado dentro de esta aura reciba daño, este modelo puede recibir el daño en su lugar. Cuando este modelo reciba daño por usar Team Player, todo el daño que exceda los PS de este modelo se le hace al modelo que recibió el ataque."
     },
     {
       "name": "Extended Reach",
@@ -15292,7 +15292,7 @@
     {
       "name": "Forceful Blow",
       "active": false,
-      "text": "Cuando este modelo hace un ataque exitoso durante un carga, después de resolver los resultados de la Playbook, el modelo oponente objetivo recibe un Push de 2″ alejándose directamente de este modelo y 2 DAÑO."
+      "text": "Cuando este modelo hace un ataque exitoso durante una carga, después de resolver los resultados de la Playbook, el modelo enemigo objetivo recibe un Push de 2″ alejándose directamente de este modelo y 2 DAÑO."
     },
     {
       "name": "Guild Rule: Secret Tunnel",
@@ -15302,27 +15302,27 @@
     {
       "name": "Stop, Drop, and Mole",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, el modelo aliado objetivo dentro 4″ puede quitarse todas las condiciones que tenga."
+      "text": "Una vez por turno durante la activación de este modelo, el modelo aliado objetivo dentro de 4″ puede quitarse todas las condiciones que tenga."
     },
     {
       "name": "You're Coming With Me",
       "active": false,
-      "text": "Una vez por turno durante la activación de este modelo, antes que este modelo sea posicionado, elegí un modelo aliado en contacto peana con peana con este modelo. Después que este modelo sea posicionado, posiciona el modelo elegido en contacto peana con peana con este modelo."
+      "text": "Una vez por turno durante la activación de este modelo, antes que este modelo sea posicionado, elige un modelo aliado en contacto base con base con este modelo. Después que este modelo sea posicionado, posiciona el modelo elegido en contacto base con base con este modelo."
     },
     {
       "name": "Remote Detonation",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si hay una pelota libre dentro de 6″ de este modelo, este modelo puede hacer una Kick como si estuviera en posesión d ela pelota. La distancia y trayectoria de esta kick son medidos desde la posición actual de la pelota libre."
+      "text": "Una vez por turno durante la activación de este modelo, si hay una pelota libre dentro de 6″ de este modelo, este modelo puede hacer una Kick como si estuviera en posesión de la pelota. La distancia y trayectoria de esta kick son medidos desde la posición actual de la pelota libre."
     },
     {
       "name": "Sapper's Instincts",
       "active": false,
-      "text": "Este modelo obtiene +2 DEF contra Character Plays de modelos oponentes."
+      "text": "Este modelo obtiene +2 DEF contra Character Plays de modelos enemigos."
     },
     {
       "name": "Voodoo Strings",
       "active": true,
-      "text": "Durante la activación de este modelo, cuando causa daños a un modelo oponente con uno o más resultados de daño de la Playbook, elegí un modelo dentro de esta aura. El modelo elegido reciben un Push de 2″. Cada modelo sólo puede ser empujado por Hilos voodoo una vez por turno."
+      "text": "Durante la activación de este modelo, cuando causa daños a un modelo enemigo con uno o más resultados de daño de la Playbook, elige un modelo dentro de esta aura. El modelo elegido recibe un Push de 2″. Cada modelo sólo puede recibir un Push por Voodoo Strings una vez por turno."
     },
     {
       "name": "Control Strings",
@@ -15332,7 +15332,7 @@
     {
       "name": "Grave Candle",
       "active": true,
-      "text": "When a friendly modelo in this aura is reduced to 0 HP, before suffering the taken out condition it may clear conditions and recover health up to its recovery level. If it does, the enemy team gains 2 VP."
+      "text": "Cuando un modelo aliado dentro de esta aura es reducido a 0 PS, antes de recibir la condición de Taken Out puede quitarse todas las condiciones y recuperar PS hasta su nivel de recuperación. Si lo hace, el equipo enemigo gana 2 VP."
     },
     {
       "name": "Creeping Dread",
@@ -15342,22 +15342,22 @@
     {
       "name": "Dark Doubts",
       "active": false,
-      "text": "Cuando este modelo recibe la condición de Knocked Out como resultado de un ataque o Character Play de un modelo oponente, después de resolver el ataque o Character Play el equipo oponente recibe -2 MP."
+      "text": "Cuando este modelo recibe la condición de Taken Out como resultado de un ataque o Character Play de un modelo enemigo, después de resolver el ataque o Character Play el equipo enemigo recibe -2 MP."
     },
     {
       "name": "Slippery",
       "active": false,
-      "text": "Este modelo obtiene +1 DEF contra ataques de oportunidad que reciba."
+      "text": "Este modelo obtiene +1 DEF contra Parting Blows que reciba."
     },
     {
       "name": "One, Two!",
       "active": false,
-      "text": "Cuando este modelo hace un pase al modelo aliado mencionado, este modelo obtiene +2/+2″ KICK mientras haga el pase. Cuando el modelo mencionado recibe un pase exitoso de este modelo, el modelo mencionado puede gastar 1 MP menos para usar Pase en movimiento o hacer un Remate de Primera."
+      "text": "Cuando este modelo hace un pase al modelo aliado mencionado, este modelo obtiene +2/+2″ KICK mientras haga el pase. Cuando el modelo mencionado recibe un pase exitoso de este modelo, el modelo mencionado puede gastar 1 MP menos para usar Pass & Move o hacer un Snap Shot."
     },
     {
       "name": "Thought",
       "active": true,
-      "text": "Al comienzo de la activación de este modelo, si el modelo aliado mencionado tiene la condición de Knocked Out sacale la condición de Knocked Out y posicionalodentro de 2″ de este modelo con todos los PS."
+      "text": "Al comienzo de la activación de este modelo, si el modelo aliado mencionado tiene la condición de Taken Out sácale la condición de Taken Out y posiciónalo dentro de 2″ de este modelo con todos los PS."
     },
     {
       "name": "Benched",
@@ -15367,27 +15367,27 @@
     {
       "name": "Inanimate Object",
       "active": false,
-      "text": "Este modelo no tiene una activación. Este modelo no genera PV cuando sufre la condición de Knocked Out. Este modelo no vuelve al juego durante la Fase de Mantenimiento si tiene la condición de Knocked Out."
+      "text": "Este modelo no tiene una activación. Este modelo no genera VP cuando sufre la condición de Taken Out. Este modelo no vuelve al juego durante la Fase de Mantenimiento si tiene la condición de Taken Out."
     },
     {
       "name": "Foul Odour",
       "active": false,
-      "text": "Los modelos oponentes tratan esta aura como terreno difícil."
+      "text": "Los modelos enemigos tratan esta aura como terreno difícil."
     },
     {
       "name": "The Knowledge",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí un modelo aliado dentro de 6″. El modelo aliado elegido obtiene +0/+2″ KICK hasta el final del turno."
+      "text": "Una vez por turno durante la activación de este modelo, elige un modelo aliado dentro de 6″. El modelo aliado elegido obtiene +0/+2″ KICK hasta el final del turno."
     },
     {
       "name": "Rising Anger",
       "active": false,
-      "text": "La primera vez que este modelo sea dañado por un modelo oponente cada turno, el equipo aliado recibe 2 MP."
+      "text": "La primera vez que este modelo sea dañado por un modelo enemigo cada turno, el equipo aliado recibe 2 MP."
     },
     {
       "name": "Soul Seer",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede recibir 3 DAÑO par gastar 1 influencia menos para usar una Character Play ."
+      "text": "Una vez por turno durante la activación de este modelo, puede recibir 3 DAÑO para gastar 1 influencia menos para usar una Character Play."
     },
     {
       "name": "Kick Support",
@@ -15407,17 +15407,17 @@
     {
       "name": "Stormwind",
       "active": false,
-      "text": "Cuando un modelo impacta a un modelo oponente con una Character Play, el modelo oponente recibe la condición de Knocked Down."
+      "text": "Cuando este modelo impacta a un modelo enemigo con una Character Play, el modelo enemigo recibe la condición de Knocked Down."
     },
     {
       "name": "About Their Necks",
       "active": false,
-      "text": "La primera vez cada turno que este modelo recibe daño por un ataque o Character Play de un modelo oponente, los modelos oponentes reciben -1 TAC hasta el final del turno."
+      "text": "La primera vez cada turno que este modelo recibe daño por un ataque o Character Play de un modelo enemigo, los modelos enemigos reciben -1 TAC hasta el final del turno."
     },
     {
       "name": "Gladiator",
       "active": false,
-      "text": "Cuando este modelo declara un contraataque, obtiene +1 DEF por la duración del ataque del modelo oponente."
+      "text": "Cuando este modelo declara un contraataque, obtiene +1 DEF por la duración del ataque del modelo enemigo."
     },
     {
       "name": "Blessings of Old",
@@ -15432,7 +15432,7 @@
     {
       "name": "Don't Get Cocky",
       "active": false,
-      "text": "Cuando este modelo recibe la condición de Knocked Out, el equipo oponente obtiene 1 VP en vez de 2 VP. Cuando este modelo vuelve a la cancha después de recibir la condición de Knocked Out, considera la zona de despliegue del oponente como propia."
+      "text": "Cuando este modelo recibe la condición de Taken Out, el equipo enemigo obtiene 1 VP en vez de 2 VP. Cuando este modelo vuelve a la cancha después de recibir la condición de Taken Out, considera la zona de despliegue del enemigo como propia."
     },
     {
       "name": "Stellar Navigation",
@@ -15442,7 +15442,7 @@
     {
       "name": "Scores for Fun",
       "active": false,
-      "text": "Cuando este modelo hace un remate durante su activación, the DT se reduce en 1."
+      "text": "Cuando este modelo hace un Shot durante su activación, el TN se reduce en 1."
     },
     {
       "name": "Playmaker",
@@ -15452,17 +15452,17 @@
     {
       "name": "Flagellant",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, este modelo puede elegí un modelo aliado dentro de 4″. El modelo elegido se quita todas las condiciones y este modelo recibe 4 DAÑO."
+      "text": "Una vez por turno durante la activación de este modelo, este modelo puede elegir un modelo aliado dentro de 4″. El modelo elegido se quita todas las condiciones y este modelo recibe 4 DAÑO."
     },
     {
       "name": "Potbellied Pass",
       "active": true,
-      "text": "Una vez por turno cuando este modelo recibe un pase con éxito, en vez de usar Pase en movimiento hacer un Remate de Primera, puede gastar 1 MP para hacer un pase sin gastar influencia."
+      "text": "Una vez por turno cuando este modelo recibe un pase con éxito, en vez de usar Pass & Move o hacer un Snap Shot, puede gastar 1 MP para hacer un pase sin gastar influencia."
     },
     {
       "name": "Impart Faith",
       "active": false,
-      "text": "Cuando este modelo usa una Character Play, el alcance de la Character Play puede ser medida desde un modelo aliado dentro de esta aura en vez de desde este modelo ."
+      "text": "Cuando este modelo usa una Character Play, el alcance de la Character Play puede ser medida desde un modelo aliado dentro de esta aura en vez de desde este modelo."
     },
     {
       "name": "Skilled within Shadow",
@@ -15472,7 +15472,7 @@
     {
       "name": "Haunting Melody",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, este modelo puede elegir un modelo oponente dentro de 8″. El jugador oponente elige uno de los siguientes:\n- Este modelo hace un Jog hacia el modelo elegido.\n- El modelo elegido hace un Jog hacia este modelo y es un modelo aliado durante esta acción."
+      "text": "Una vez por turno durante la activación de este modelo, este modelo puede elegir un modelo enemigo dentro de 8″. El jugador enemigo elige uno de los siguientes:\n- Este modelo hace un Jog hacia el modelo elegido.\n- El modelo elegido hace un Jog hacia este modelo y es un modelo aliado durante esta acción."
     },
     {
       "name": "Predatory Instinct",
@@ -15492,17 +15492,17 @@
     {
       "name": "Virulent Strain",
       "active": false,
-      "text": "Los modelos oponentes dentro de esta aura que tengan la condición de Disease reciben -1 TAC y -1 DEF."
+      "text": "Los modelos enemigos dentro de esta aura que tengan la condición de Disease reciben -1 TAC y -1 DEF."
     },
     {
       "name": "Cloak of Rats",
       "active": true,
-      "text": "Al final de la activación de este modelo, el jugador oponente elige uno de los siguientes:\n- Los modelos oponentes dentro de este pulso reciben la condición de atrapado.\n- Los modelos oponentes dentro de este pulso reciben 3 DAÑO."
+      "text": "Al final de la activación de este modelo, el jugador enemigo elige uno de los siguientes:\n- Los modelos enemigos dentro de este pulso reciben la condición de Snared.\n- Los modelos enemigos dentro de este pulso reciben 3 DAÑO."
     },
     {
       "name": "Grim Caress",
       "active": false,
-      "text": "Cuando un modelo oponente termina su activación trabado en combate con este modelo, el modelo oponente recibe 3 DAÑO."
+      "text": "Cuando un modelo enemigo termina su activación trabado en combate con este modelo, el modelo enemigo recibe 3 DAÑO."
     },
     {
       "name": "Killer",
@@ -15527,52 +15527,52 @@
     {
       "name": "Sheep Become the Shepherds",
       "active": false,
-      "text": "Si este modelo recibe la condición de Knocked Out durante la Fase de Activación, los modelos aliados son alocados influencia hasta su máxima INF."
+      "text": "Si este modelo recibe la condición de Taken Out durante la Fase de Activación, los modelos aliados son alocados influencia hasta su máxima INF."
     },
     {
       "name": "Heartless Brute!",
       "active": false,
-      "text": "Cuando un modelo oponente causa que este modelo reciba la condición de Knocked Out, el modelo oponente recibe Apartado hasta el final del turno.\n{{play 'Singled Out'}}"
+      "text": "Cuando un modelo enemigo causa que este modelo reciba la condición de Taken Out, el modelo enemigo recibe Singled Out hasta el final del turno.\n{{play 'Singled Out'}}"
     },
     {
       "name": "Herding",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, puede elegir un Harvest Marker aliado dentro de 2″ y removerlo de la cancha. Si lo hace, elegí un modelo oponente dentro de 3″. El modelo elegido sufre un Push de 3″."
+      "text": "Una vez por turno durante la activación de este modelo, puede elegir un Harvest Marker aliado dentro de 2″ y removerlo de la cancha. Si lo hace, elige un modelo enemigo dentro de 3″. El modelo elegido sufre un Push de 3″."
     },
     {
       "name": "Littermates",
       "active": false,
-      "text": "Si este modelo recibe la condición de Knocked Out el modelo aliado mencionado obtiene Furious y +4 TAC hasta el final del turno.\n{{trait 'Furious'}}"
+      "text": "Si este modelo recibe la condición de Taken Out el modelo aliado mencionado obtiene Furious y +4 TAC hasta el final del turno.\n{{trait 'Furious'}}"
     },
     {
       "name": "Matched Pair",
       "active": false,
-      "text": "Este modelo y el modelo aliado mencionado son tratados como un un sólo Seguidor durante la selección del equipo. Mientras el modelo mencionado esté en la cancha, este modelo activa en simultáneo con el modelo mencionado. Cuando este modelo recibe la condición de Knocked Out, el equipo oponente obtiene 1 VP en vez de  2 VP."
+      "text": "Este modelo y el modelo aliado mencionado son tratados como un sólo Seguidor durante la selección del equipo. Mientras el modelo mencionado esté en la cancha, este modelo activa en simultáneo con el modelo mencionado. Cuando este modelo recibe la condición de Taken Out, el equipo enemigo obtiene 1 VP en vez de 2 VP."
     },
     {
       "name": "Workhorse",
       "active": false,
-      "text": "Si este modelo recibe la condición de Knocked Out puede posicionar hasta 5 Harvest Marker aliados en cualquier lugar de la cancha."
+      "text": "Si este modelo recibe la condición de Taken Out puede posicionar hasta 5 Harvest Marker aliados en cualquier lugar de la cancha."
     },
     {
       "name": "Baa-ttering Ram",
       "active": false,
-      "text": "Cuando este modelo realiza un avance, los modelos cuyas peanas queden en contacto peana con peana con la peana de este modelo reciben inmediatamente reciben un Push de 4″ alejándose directamente de este modelo. Este modelo solo puede empujar a cada modelo una vez por turno con Cabr-iete"
+      "text": "Cuando este modelo realiza un avance, los modelos cuyas peanas queden en contacto base con base con la peana de este modelo reciben inmediatamente un Push de 4″ alejándose directamente de este modelo. Este modelo solo puede hacer Push a cada modelo una vez por turno con Baa-ttering Ram."
     },
     {
       "name": "Flock",
       "active": true,
-      "text": "Cuando este modelo termina un avance, otro modelo aliado dentro de este pulso pulso puede hacer un Dodge de 2″."
+      "text": "Cuando este modelo termina un avance, otro modelo aliado dentro de este pulso puede hacer un Dodge de 2″."
     },
     {
       "name": "Have You Any Wool?",
       "active": false,
-      "text": "Si este modelo recibe la condición de Knocked Out los modelos aliados obtienen +2 ARM hasta el final del turno."
+      "text": "Si este modelo recibe la condición de Taken Out los modelos aliados obtienen +2 ARM hasta el final del turno."
     },
     {
       "name": "All About The Game",
       "active": false,
-      "text": "Si este modelo recibe la condición de Knocked Out los modelos aliados obtienen +1/+1″ KICK hasta el final del turno."
+      "text": "Si este modelo recibe la condición de Taken Out los modelos aliados obtienen +1/+1″ KICK hasta el final del turno."
     },
     {
       "name": "Shearing",
@@ -15587,17 +15587,17 @@
     {
       "name": "Lance",
       "active": false,
-      "text": "Cuando este modelo hace una carga, éste modelo obtiene an additional +2 TAC y +1 DAÑO a los resultados de daño de la Playbook por la duración de la carga."
+      "text": "Cuando este modelo hace una carga, este modelo obtiene +2 TAC adicional y +1 DAÑO a los resultados de daño de la Playbook por la duración de la carga."
     },
     {
       "name": "Shelling Out",
       "active": false,
-      "text": "Los modelos aliados dentro de esta aura obtienen +1 TAC. Cuando un modelo aliado dentro de esta aura le cause la condición de Knocked Out a un modelo oponente, el equipo aliado recibe 1 MP adicional."
+      "text": "Los modelos aliados dentro de esta aura obtienen +1 TAC. Cuando un modelo aliado dentro de esta aura le cause la condición de Taken Out a un modelo enemigo, el equipo aliado recibe 1 MP adicional."
     },
     {
       "name": "Trusty Steed",
       "active": false,
-      "text": "Este modelo es tanto el Capitán como la Mascota de tu equipo. Este modelo da 2 VPs cuando recibe la condición de Knocked Out. Avarisse no puede ser seleccionado como parte de tu equipo si este modelo es tu Capitán."
+      "text": "Este modelo es tanto el Capitán como la Mascota de tu equipo. Este modelo da 2 VPs cuando recibe la condición de Taken Out. Avarisse no puede ser seleccionado como parte de tu equipo si este modelo es tu Capitán."
     },
     {
       "name": "Contract",
@@ -15607,7 +15607,7 @@
     {
       "name": "Drop Off",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si el modelo aliado mencionado no está en la cancha y no tiene la condición de Knocked Out, puede ser posicionado en la cancha en contacto base con base con este modelo."
+      "text": "Una vez por turno durante la activación de este modelo, si el modelo aliado mencionado no está en la cancha y no tiene la condición de Taken Out, puede ser posicionado en la cancha en contacto base con base con este modelo."
     },
     {
       "name": "Thuggery",
@@ -15617,7 +15617,7 @@
     {
       "name": "Pick Up",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, si este modelo no tiene posesión de la pelota y esta en contacto peana con peana con el modelo Avarisse aliado, este modelo puede quitarse todas las condiciones que tenga y removerse de la cancha."
+      "text": "Una vez por turno durante la activación de este modelo, si este modelo no tiene posesión de la pelota y esta en contacto base con base con el modelo Avarisse aliado, este modelo puede quitarse todas las condiciones que tenga y removerse de la cancha."
     },
     {
       "name": "Ready to Go",
@@ -15627,12 +15627,12 @@
     {
       "name": "Back to Black",
       "active": true,
-      "text": "Una vez por turno, durante la activación de este modelo, puede quitar la condición de Burning de un modelo aliado dentro de 6″. Si lo hace, ese modelo puede  inmediatamente hacer un Dodge de 4″."
+      "text": "Una vez por turno, durante la activación de este modelo, puede quitar la condición de Burning de un modelo aliado dentro de 6″. Si lo hace, ese modelo puede inmediatamente hacer un Dodge de 4″."
     },
     {
       "name": "Blinded by the Light",
       "active": false,
-      "text": "Mientras este modelo tenga la condición de Burning, los modelos oponentes reciben -1 TAC mientras ataquen a este modelo."
+      "text": "Mientras este modelo tenga la condición de Burning, los modelos enemigos reciben -1 TAC mientras ataquen a este modelo."
     },
     {
       "name": "Flare Out",
@@ -15662,12 +15662,12 @@
     {
       "name": "Spotlight",
       "active": false,
-      "text": "Si este modelo tiene la condición de Burning, obtiene +1/+2 KICK e ignora las penealizaciones por estar trabado en combate y modelos intervinientes cuado hace una Kick."
+      "text": "Si este modelo tiene la condición de Burning, obtiene +1/+2 KICK e ignora las penalizaciones por estar trabado en combate y modelos intervinientes cuando hace una Kick."
     },
     {
       "name": "Afterglow",
       "active": true,
-      "text": "Si este modelo tiene la condición de Burning, cuando un modelo aliado dentro de esta aura gasta MP, ese modelo puede curarse 2 PS. Cada modelo sólo puedo curarse PS por efecto de  Resplandor una vez por turno."
+      "text": "Si este modelo tiene la condición de Burning, cuando un modelo aliado dentro de esta aura gasta MP, ese modelo puede curarse 2 PS. Cada modelo sólo puede curarse PS por efecto de Afterglow una vez por turno."
     },
     {
       "name": "Now You See Me...",
@@ -15677,17 +15677,17 @@
     {
       "name": "Clumsy",
       "active": false,
-      "text": "Los modelos oponentes que entren o terminen su activación dentro de esta aura reciben la condición de Burning y la condición de Poisons."
+      "text": "Los modelos enemigos que entren o terminen su activación dentro de esta aura reciben la condición de Burning y la condición de Poison."
     },
     {
       "name": "Flash Point",
       "active": false,
-      "text": "Quitá la condición de Burning de este modelo. Si lo hacés, los modelos oponentes dentro de este pulso reciben -1″ /-1″ MOV."
+      "text": "Quita la condición de Burning de este modelo. Si lo haces, los modelos enemigos dentro de este pulso reciben -1″ /-1″ MOV."
     },
     {
       "name": "Who's a Good Boy",
       "active": true,
-      "text": "Una vez por turno, cuando este modelo use una Character Playsobre un modelo aliado, este modelo puede use the Character Playsin gastar influencia."
+      "text": "Una vez por turno, cuando este modelo use una Character Play sobre un modelo aliado mencionado, este modelo puede usar la Character Play sin gastar influencia."
     },
     {
       "name": "Prodigy",
@@ -15697,32 +15697,32 @@
     {
       "name": "Untouchable",
       "active": true,
-      "text": "Cuando este modelo hace un gol, puede usar Ágil inmediatamente sin gastar influencia."
+      "text": "Cuando este modelo hace un gol, puede usar Nimble inmediatamente sin gastar influencia."
     },
     {
       "name": "Flame On",
       "active": false,
-      "text": "Si este modelo tiene la condición de Burning, Bomba alquímica causes 2 DAÑO de condición en vez de  1."
+      "text": "Si este modelo tiene la condición de Burning, Alchemical Bomb causa 2 DAÑO de condición en vez de 1."
     },
     {
       "name": "Fission",
       "active": false,
-      "text": "Cuando este modelo haga daño a un modelo oponente en posesión de la pelota, este modelo puede quitarse la condición de Burning del modelo oponente. Si lo hace, el modelo oponente pierde la posesión de la pelota. realiza un desvío circular con la plantilla centrada en el modelo oponente."
+      "text": "Cuando este modelo haga daño a un modelo enemigo en posesión de la pelota, este modelo puede quitar la condición de Burning del modelo enemigo. Si lo hace, el modelo enemigo pierde la posesión de la pelota. Realiza un desvío circular con la plantilla centrada en el modelo enemigo."
     },
     {
       "name": "Fusion",
       "active": false,
-      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning or condición de Poison de otro modelo dentro de 4″. Si lo hace, los modelos dentro de este pulso reciben la condición de Burning."
+      "text": "Una vez por turno durante la activación de este modelo, puede remover la condición de Burning o la condición de Poison de otro modelo dentro de 4″. Si lo hace, los modelos dentro de este pulso reciben la condición de Burning."
     },
     {
       "name": "Rejuvenation",
       "active": false,
-      "text": "Cuando un modelo aliado dentro de esta aura se cura PS, se cura  1 PS adicional."
+      "text": "Cuando un modelo aliado dentro de esta aura se cura PS, se cura 1 PS adicional."
     },
     {
       "name": "Showboater",
       "active": false,
-      "text": "Una vez por turno, cuando este modelo se hace objetivo de una  Character Play, puede reducir el costo de la Character Play en 1."
+      "text": "Una vez por turno, cuando este modelo se hace objetivo de una Character Play, puede reducir el costo de la Character Play en 1."
     },
     {
       "name": "Repointing",
@@ -15732,17 +15732,17 @@
     {
       "name": "Dread Omen",
       "active": false,
-      "text": "Este modelo obtiene +2 TAC mientras algún modelo tenga la condición de Knocked Out."
+      "text": "Este modelo obtiene +2 TAC mientras algún modelo tenga la condición de Taken Out."
     },
     {
       "name": "Wraith Walk",
       "active": false,
-      "text": "Cuando este modelo se mueva esquivando o avanzando, puede pasar por osbre las peanas de otros modelos. No puede terminar el movimiento solapando la peana de otro modelo."
+      "text": "Cuando este modelo se mueva haciendo un Dodge o avanzando, puede pasar por sobre las peanas de otros modelos. No puede terminar el movimiento solapando la peana de otro modelo."
     },
     {
       "name": "Confidence",
       "active": true,
-      "text": "Una vez durante la activación de este modelo, podés elegir un modelo aliado dentro de 4″. El modelo elegido puede volver a tirar cualquier cantidad de dados de la próxima tirada que haga el modelo este turno."
+      "text": "Una vez durante la activación de este modelo, puedes elegir un modelo aliado dentro de 4″. El modelo elegido puede volver a tirar cualquier cantidad de dados de la próxima tirada que haga el modelo este turno."
     },
     {
       "name": "Rabid Frenzy",
@@ -15752,22 +15752,22 @@
     {
       "name": "Verminthirst",
       "active": false,
-      "text": "Cuando otro modelo recibe la condición de Knocked Out dentro de esta aura, después de que la acción actual sea resuelta, este modelo puede curarse 2 PS."
+      "text": "Cuando otro modelo recibe la condición de Taken Out dentro de esta aura, después de que la acción actual sea resuelta, este modelo puede curarse 2 PS."
     },
     {
       "name": "Stealthy",
       "active": false,
-      "text": "Las Character Plays de modelos oponentes que hagan objetivo a este modelo reciben –5″ RNG."
+      "text": "Las Character Plays de modelos enemigos que hagan objetivo a este modelo reciben -5″ RNG."
     },
     {
       "name": "Poisoner",
       "active": false,
-      "text": "Cada vez que este modelo haga un dodge, después de la que la acción sea resuelta, elegí un modelo oponente dentro de 4″. El modelo elegido recibe la condición de Poison."
+      "text": "Cada vez que este modelo haga un dodge, después de la que la acción sea resuelta, elige un modelo enemigo dentro de 4″. El modelo elegido recibe la condición de Poison."
     },
     {
       "name": "Chameleon",
       "active": false,
-      "text": "Cuando este modelo vuelve a la cancha después de recibir la condición de Knocked Out, considera la zona de despliegue del oponente como propia."
+      "text": "Cuando este modelo vuelve a la cancha después de recibir la condición de Taken Out, considera la zona de despliegue del enemigo como propia."
     },
     {
       "name": "Subsistence",
@@ -15782,12 +15782,12 @@
     {
       "name": "Caber Toss",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, podés elegir un Log Pile aliado dentro de 1″ de este modelo . Posiciona el otro Log Pile dentro de 4″ de este modelo ."
+      "text": "Una vez por turno durante la activación de este modelo, puedes elegir un Log Pile aliado dentro de 1″ de este modelo. Posiciona el otro Log Pile dentro de 4″ de este modelo."
     },
     {
       "name": "Splitting Strikes",
       "active": false,
-      "text": "While dentro de 1″ of a friendly log pile marker, when this modelo makes a successful attack y selects one or more resultados de daño de la Playbook, choose another enemy modelo within this model's melee zone. El modelo elegido recibe 2 DAÑO."
+      "text": "Mientras esté dentro de 1″ de un Log Pile aliado, cuando este modelo haga un ataque con éxito y elija uno o más resultados de daño de la Playbook, elige otro modelo enemigo dentro de la Melee Zone de este modelo. El modelo elegido recibe 2 DAÑO."
     },
     {
       "name": "Hew Do They Think They Are",
@@ -15797,22 +15797,22 @@
     {
       "name": "Eye of the Sun Father",
       "active": false,
-      "text": "Una vez por turno durante la activación de este modelo, si hay un marcador aliado dentro de 4″ de este modelo, este modelo puede hacer un pase or use a Character Playsin gastar influencia."
+      "text": "Una vez por turno durante la activación de este modelo, si hay un Log Pile aliado dentro de 4″ de este modelo, este modelo puede hacer un pase o usar una Character Play sin gastar influencia."
     },
     {
       "name": "Synchronised",
       "active": false,
-      "text": "Cuando este modelo aliado mencionado recibe un pase exitoso de este modelo, el modelo mencionaod pueden gastar 1 MP menos para usar Pase en movimiento o hacer un Remate de Primera."
+      "text": "Cuando este modelo aliado mencionado recibe un pase exitoso de este modelo, el modelo mencionado puede gastar 1 MP menos para usar Pass & Move o hacer un Snap Shot."
     },
     {
       "name": "Putting Out Fires",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, elegí un Log Pile aliado y remueve cualquier cantidad de influencia de modelos dentro de 4″ del Log Pile elegido. Luego, aloca la influencia removida entre los modelos dentro de 4″ del Log Pile elegido."
+      "text": "Una vez por turno durante la activación de este modelo, elige un Log Pile aliado y remueve cualquier cantidad de influencia de modelos aliados dentro de 4″ del Log Pile elegido. Luego, aloca la influencia removida entre otros modelos aliados dentro de 4″ del Log Pile elegido."
     },
     {
       "name": "Den Protector",
       "active": false,
-      "text": "Cuando este modelo declara una carga a un modelo oponente dentro de 1″ de un Log Pile aliado, puede hacerlo sin gastar influencia."
+      "text": "Cuando este modelo declara una carga a un modelo enemigo dentro de 1″ de un Log Pile aliado, puede hacerlo sin gastar influencia."
     },
     {
       "name": "Hunker Down",
@@ -15827,32 +15827,32 @@
     {
       "name": "Specialised Equipment",
       "active": false,
-      "text": "Este modelo no puede ser elegido para el equipo pero es añadido automáticamente cuando los modelos mencionados es elegido para el equipo. Este modelo no cuenta para el tamaño máximo del equipo."
+      "text": "Este modelo no puede ser elegido para el equipo pero es añadido automáticamente cuando los modelos mencionados son elegidos para el equipo. Este modelo no cuenta para el tamaño máximo del equipo."
     },
     {
       "name": "Early Risers",
       "active": false,
-      "text": "Al comienzo de la activación de este modelo, pude ser posicionado dentro de 1″ de su posición actual."
+      "text": "Al comienzo de la activación de este modelo, puede ser posicionado dentro de 1″ de su posición actual."
     },
     {
       "name": "Job's a Good'un",
       "active": false,
-      "text": "Cuando este modelo recibe la condición de Knocked Out as como resultado de un ataque o Character Play, los modelos oponentes dentro de la Melee Zone reciben la condición de Knocked Down. Después de remover a este modelo de la cancha, reemplaza la carta de este modelo por las cartas de Cross y Cut."
+      "text": "Cuando este modelo recibe la condición de Taken Out como resultado de un ataque o Character Play, los modelos enemigos dentro de la Melee Zone reciben la condición de Knocked Down. Después de remover a este modelo de la cancha, reemplaza la carta de este modelo por las cartas de Cross y Cut."
     },
     {
       "name": "Victory Toast",
       "active": true,
-      "text": "Cuando este modelo hace un gol, obtiene un Beer Token. Además, este modelo puede usar Beer Tokens para usar Rest.."
+      "text": "Cuando este modelo hace un gol, obtiene un Beer Token. Además, este modelo puede usar Beer Tokens para usar Rest."
     },
     {
       "name": "Brute Force",
       "active": false,
-      "text": "Al principio de la activación de este modelo, elegí un modelo oponente dentro de la Melee Zone de este modelo. El modelo elegido recibe un Push de 2″ alejándose directamente de este modelo."
+      "text": "Al principio de la activación de este modelo, elige un modelo enemigo dentro de la Melee Zone de este modelo. El modelo elegido recibe un Push de 2″ alejándose directamente de este modelo."
     },
     {
       "name": "Nose Out of Joint",
       "active": false,
-      "text": "Si un modelo oponente hace un gol mientras que este modelo dentro de 4″ del arco aliado, este modelo obtiene Furious hasta el final de la partida.\n{{trait 'Furious'}}"
+      "text": "Si un modelo enemigo hace un gol mientras que este modelo esté dentro de 4″ del arco aliado, este modelo obtiene Furious hasta el final de la partida.\n{{trait 'Furious'}}"
     },
     {
       "name": "Old Reliable",
@@ -15867,12 +15867,12 @@
     {
       "name": "Poltergeists",
       "active": true,
-      "text": "Al comienzo de la activación de cada modelo aliado, un modelo aliado dentro de esta aura puede hacer un Dodge de 2″. Los otros modelos solo sólo pueden hacer un Dodge como resultado de  Poltergeists una vez por turno."
+      "text": "Al comienzo de la activación de cada modelo aliado, un modelo aliado dentro de esta aura puede hacer un Dodge de 2″. Los otros modelos sólo pueden hacer un Dodge como resultado de Poltergeists una vez por turno."
     },
     {
       "name": "Murder Spree",
       "active": true,
-      "text": "Una vez por turno durante la activación de este modelo, cuando haga que un modelo oponente reciba la condición de Knocked Out, este modelo puede hacer un Dodge de 4″ o usar una Character Playsin gastar influencia como su próxima acción."
+      "text": "Una vez por turno durante la activación de este modelo, cuando haga que un modelo enemigo reciba la condición de Taken Out, este modelo puede hacer un Dodge de 4″ o usar una Character Play sin gastar influencia como su próxima acción."
     },
     {
       "name": "Brutal",
@@ -15882,7 +15882,7 @@
     {
       "name": "Finisher",
       "active": false,
-      "text": "Los modelos oponente con 9 o menos HP reiben -1 DEF contra ataques de este modelo."
+      "text": "Los modelos enemigos con 9 o menos HP reciben -1 DEF contra ataques de este modelo."
     }
   ]
 }


### PR DESCRIPTION
This fixes multiple issues in the spanish translation, including:
 - multiple typos (missing letters, missing periods at the end, missing spaces, etc.)
 - incorrect translations ('enemy' was 'oponente' instead of 'enemigo', etc.)
 - argentinian 'vos' form instead of more widespread 'tu' form
 - inconsistent usage of english names for traits and plays: the original names were kept, but were referenced by their spanish translation in text. Only english names are used now
 - inconsistent usage of spanish names for english terms: 'push' was sometimes translated as 'empujar' or similar. Only the original english terms are used now, except for common actions (like attacks and passes). This follows the work done in the french translation.
 - incorrect rulings due to translation errors, e.g. Theron's legendary had been changed to only target strikers

There may still be some more errors that need fixing, but this should leave the spanish translation in a much better place.

---

I'm not sure if `pwa` is the correct branch to target, I'm not very familiar with mobile apps. Feel free to change the base branch if needed. Thanks for the work on the app!